### PR TITLE
Rename `HUGGINGFACE_API_KEY` to `HF_TOKEN`

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -166,7 +166,7 @@ Below is a sample command you can use to start a benchmark. The command will con
 
 ```shell
 # Optional. This is required when you load the tokenizer from huggingface.co with a model-id
-export HUGGINGFACE_API_KEY="<your-key>"  
+export HF_TOKEN="<your-key>"  
 # HF transformers will log a warning about torch not installed, since benchmark doesn't really need torch 
 # and cuda, we use this env to disable the warning
 export TRANSFORMERS_VERBOSITY=error 
@@ -580,7 +580,7 @@ docker run \
     -tid \
     --shm-size 5g \
     --ulimit nofile=65535:65535 \
-    --env HUGGINGFACE_API_KEY="your_huggingface_api_key" \
+    --env HF_TOKEN="your_HF_TOKEN" \
     --network benchmark-network \
     -v /mnt/data/models:/models \
     -v $(pwd)/llava-config.json:/genai-bench/llava-config.json \
@@ -630,7 +630,7 @@ docker run \
     -tid \
     --shm-size 5g \
     --ulimit nofile=65535:65535 \
-    --env HUGGINGFACE_API_KEY="your_huggingface_api_key" \
+    --env HF_TOKEN="your_HF_TOKEN" \
     --network benchmark-network \
     -v /mnt/data/models:/models \
     -v $HOST_OUTPUT_DIR:$CONTAINER_OUTPUT_DIR \

--- a/genai_bench/cli/validation.py
+++ b/genai_bench/cli/validation.py
@@ -139,10 +139,10 @@ def validate_tokenizer(model_tokenizer):
         # Load the tokenizer directly from the local path
         tokenizer = AutoTokenizer.from_pretrained(model_tokenizer)
     else:
-        hf_token = os.environ.get("HUGGINGFACE_API_KEY")
+        hf_token = os.environ.get("HF_TOKEN")
         if hf_token is None:
             raise click.BadParameter(
-                "The HUGGINGFACE_API_KEY environment variable is not set. "
+                "The HF_TOKEN environment variable is not set. "
                 "It is a required parameter to download tokenizer from "
                 "HuggingFace."
             )

--- a/genai_bench/data/sources.py
+++ b/genai_bench/data/sources.py
@@ -101,11 +101,11 @@ class HuggingFaceDatasetSource(DatasetSource):
 
         # Verify dataset exists
         try:
-            dataset_info(self.config.path, token=os.environ.get("HUGGINGFACE_API_KEY"))
+            dataset_info(self.config.path, token=os.environ.get("HF_TOKEN"))
         except DatasetNotFoundError as e:
             raise ValueError(
                 f"Dataset '{self.config.path}' not found on HuggingFace Hub. "
-                f"If it's a gated repo, please set HUGGINGFACE_API_KEY environment "
+                f"If it's a gated repo, please set HF_TOKEN environment "
                 f"variable."
             ) from e
 

--- a/tests/cli/test_cli_benchmark.py
+++ b/tests/cli/test_cli_benchmark.py
@@ -60,7 +60,7 @@ def default_options():
 
 @pytest.fixture
 def mock_env_variables():
-    with patch.dict("os.environ", {"HUGGINGFACE_API_KEY": "dummy_key"}):
+    with patch.dict("os.environ", {"HF_TOKEN": "dummy_key"}):
         yield  # Yield ensures the patch is active for the duration of the test
 
 

--- a/tests/cli/test_validation.py
+++ b/tests/cli/test_validation.py
@@ -134,7 +134,7 @@ def test_validate_tokenizer_with_hf_api(monkeypatch):
     hf_token = "mock_api_key"
     mock_tokenizer = MagicMock()
 
-    monkeypatch.setenv("HUGGINGFACE_API_KEY", hf_token)
+    monkeypatch.setenv("HF_TOKEN", hf_token)
 
     with patch(
         "transformers.AutoTokenizer.from_pretrained",
@@ -151,7 +151,7 @@ def test_validate_tokenizer_with_hf_api(monkeypatch):
 
 def test_validate_tokenizer_no_hf_token(monkeypatch):
     monkeypatch.setattr(Path, "exists", lambda self: False)
-    monkeypatch.delenv("HUGGINGFACE_API_KEY", raising=False)
+    monkeypatch.delenv("HF_TOKEN", raising=False)
 
     model_name = "bert-base-uncased"
 


### PR DESCRIPTION
**Motivation**
`HUGGINGFACE_API_KEY` is a stale name. It is long, hard to type, and error-prone. `HF_TOKEN` is a better name as huggingface uses token as the name,

**Changes**
- Rename `HUGGINGFACE_API_KEY` to `HF_TOKEN`