### PR TITLE
refactor: Update `image-to-text` to `image-text-to-text`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,7 @@ Each `User` corresponds to one API backend, such as [`OpenAIUser`](genai_bench/u
 class OpenAIUser(BaseUser):
     supported_tasks = {
         "text-to-text": "chat",
-        "image-to-text": "chat",
+        "image-text-to-text": "chat",
         "text-to-embeddings": "embeddings",
         "audio-to-text": "audio_to_text",  # New task added
     }

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -115,12 +115,12 @@ Here are the currently supported tasks:
 
 **NOTE**: Task compatibility may vary depending on the API format.
 
-| Task Name             | Description                                                                  |
-|-----------------------|------------------------------------------------------------------------------|
-| `text-to-text`        | Benchmarks generating text output from text input, such as chat or QA tasks. |
-| `text-to-embeddings`  | Benchmarks generating embeddings from text input, often for semantic search. |
-| `image-to-text`       | Benchmarks generating text from images, such as visual question answering.   |
-| `image-to-embeddings` | Benchmarks generating embeddings from images, often for image similarity.    |
+| Task Name             | Description                                                                                 |
+|-----------------------|---------------------------------------------------------------------------------------------|
+| `text-to-text`        | Benchmarks generating text output from text input, such as chat or QA tasks.                |
+| `text-to-embeddings`  | Benchmarks generating embeddings from text input, often for semantic search.                |
+| `image-text-to-text`  | Benchmarks generating text from images and text prompts, such as visual question answering. |
+| `image-to-embeddings` | Benchmarks generating embeddings from images, often for image similarity.                   |
 
 <!-- TOC --><a name="how-tasks-work"></a>
 

--- a/genai_bench/cli/option_groups.py
+++ b/genai_bench/cli/option_groups.py
@@ -44,7 +44,7 @@ def api_options(func):
                 "text-to-text",
                 "text-to-embeddings",
                 "text-to-rerank",
-                "image-to-text",
+                "image-text-to-text",
                 "image-to-embeddings",
             ],
             case_sensitive=False,
@@ -54,7 +54,7 @@ def api_options(func):
         callback=validate_task,
         help="The task to benchmark: it follows `<input_modality>-to-"
         "<output_modality>` pattern. Currently we support `text-to-text`,"
-        " `image-to-text`, `text-to-embeddings, and `image-to-embeddings`.",
+        " `image-text-to-text`, `text-to-embeddings, and `image-to-embeddings`.",
     )(func)
     func = click.option(
         "--api-key",

--- a/genai_bench/cli/validation.py
+++ b/genai_bench/cli/validation.py
@@ -59,7 +59,7 @@ DEFAULT_SCENARIOS_FOR_RERANK = [
 DEFAULT_SCENARIOS_BY_TASK = {
     "text-to-text": DEFAULT_SCENARIOS_FOR_CHAT,
     "text-to-rerank": DEFAULT_SCENARIOS_FOR_RERANK,
-    "image-to-text": DEFAULT_SCENARIOS_FOR_VISION,
+    "image-text-to-text": DEFAULT_SCENARIOS_FOR_VISION,
     "text-to-embeddings": DEFAULT_SCENARIOS_FOR_EMBEDDING,
     "image-to-embeddings": DEFAULT_SCENARIOS_FOR_VISION,
     # add other tasks and default scenarios as needed
@@ -78,7 +78,7 @@ def validate_dataset_path_callback(ctx, param, value):
         )
 
     input_modality, output_modality = task.split("-to-")
-    if input_modality == "image" and value is None:
+    if "image" in input_modality and value is None:
         # Check if dataset_config is provided as alternative
         dataset_config = ctx.params.get("dataset_config")
         if dataset_config is None:

--- a/genai_bench/data/loaders/factory.py
+++ b/genai_bench/data/loaders/factory.py
@@ -33,7 +33,7 @@ class DataLoaderFactory:
 
         if input_modality == "text":
             return DataLoaderFactory._load_text_data(dataset_config, output_modality)
-        elif input_modality == "image":
+        elif "image" in input_modality:
             return DataLoaderFactory._load_image_data(dataset_config), False
         else:
             raise ValueError(f"Unsupported input modality: {input_modality}")

--- a/genai_bench/sampling/image.py
+++ b/genai_bench/sampling/image.py
@@ -21,14 +21,14 @@ logger = init_logger(__name__)
 class ImageSampler(Sampler):
     """
     A sampler for image-based tasks, supporting multiple output modalities:
-    - `image-to-text`: Generates `UserImageChatRequest` for vision-based chat
+    - `image-text-to-text`: Generates `UserImageChatRequest` for vision-based chat
       tasks.
     - `image-to-embeddings`: Generates `UserImageEmbeddingRequest` for image
       embedding tasks.
     """
 
     input_modality = "image"
-    supported_tasks = {"image-to-text", "image-to-embeddings"}
+    supported_tasks = {"image-text-to-text", "image-to-embeddings"}
 
     def __init__(
         self,
@@ -75,7 +75,7 @@ class ImageSampler(Sampler):
         num_output_tokens: int,
     ) -> UserImageChatRequest:
         """
-        Generates a `UserImageChatRequest` for image-to-text tasks.
+        Generates a `UserImageChatRequest` for image-text-to-text tasks.
 
         Args:
             prompt (str): The textual prompt accompanying the images.
@@ -84,7 +84,7 @@ class ImageSampler(Sampler):
             num_output_tokens (int): Number of output tokens expected.
 
         Returns:
-            UserImageChatRequest: A request object for image-to-text tasks.
+            UserImageChatRequest: A request object for image-text-to-text tasks.
         """
         return UserImageChatRequest(
             model=self.model,

--- a/genai_bench/user/openai_user.py
+++ b/genai_bench/user/openai_user.py
@@ -28,7 +28,7 @@ class OpenAIUser(BaseUser):
     BACKEND_NAME = "openai"
     supported_tasks = {
         "text-to-text": "chat",
-        "image-to-text": "chat",
+        "image-text-to-text": "chat",
         "text-to-embeddings": "embeddings",
         # Future support can be added here
     }

--- a/tests/cli/test_validation.py
+++ b/tests/cli/test_validation.py
@@ -227,12 +227,12 @@ def test_validate_dataset_path_callback(caplog):
     param = None
 
     # Test with image task and dataset path
-    ctx.params = {"task": "image-to-text"}
+    ctx.params = {"task": "image-text-to-text"}
     result = validate_dataset_path_callback(ctx, param, "/path/to/dataset")
     assert result == "/path/to/dataset"
 
     # Test with image task and missing dataset path (no dataset config)
-    ctx.params = {"task": "image-to-text", "dataset_config": None}
+    ctx.params = {"task": "image-text-to-text", "dataset_config": None}
     with pytest.raises(click.BadParameter) as exc:
         validate_dataset_path_callback(ctx, param, None)
     assert (
@@ -242,7 +242,10 @@ def test_validate_dataset_path_callback(caplog):
 
     # Test with image task, missing dataset path, but dataset config provided
     with caplog.at_level(logging.WARNING):
-        ctx.params = {"task": "image-to-text", "dataset_config": "/path/to/config.json"}
+        ctx.params = {
+            "task": "image-text-to-text",
+            "dataset_config": "/path/to/config.json",
+        }
         result = validate_dataset_path_callback(ctx, param, None)
         assert result is None
     assert "Using dataset configuration file for image task" in caplog.text

--- a/tests/data/loaders/test_factory.py
+++ b/tests/data/loaders/test_factory.py
@@ -71,7 +71,7 @@ def test_load_data_for_image_task():
         mock_loader_class.return_value = mock_loader
 
         data, use_scenario = DataLoaderFactory.load_data_for_task(
-            "image-to-text", config
+            "image-text-to-text", config
         )
 
         assert data == [("prompt1", "image1"), ("prompt2", "image2")]

--- a/tests/sampling/test_base.py
+++ b/tests/sampling/test_base.py
@@ -42,7 +42,7 @@ def test_sampler_factory(mock_vision_dataset):
     assert isinstance(sampler, TextSampler)
 
     sampler = Sampler.create(
-        task="image-to-text",
+        task="image-text-to-text",
         tokenizer=Mock(),
         model="gpt-3",
         data=mock_vision_dataset,


### PR DESCRIPTION
## Motivations

Completes #1 
Rename ambiguous task image-to-text to image-text-to-text to better reflect that it takes both image and text inputs.

## Changes
  1. USER_GUIDE.md - Updated task description and all command examples
  2. CONTRIBUTING.md - Updated task mapping in OpenAI user example
  3. genai_bench/cli/validation.py - Updated default scenarios mapping and validation logic
  4. genai_bench/cli/option_groups.py - Updated CLI task choices and help text
  5. genai_bench/data/loaders/factory.py - Updated data loader selection logic
  6. genai_bench/sampling/base.py - Enhanced factory method to handle composite input modalities
  7. genai_bench/sampling/image.py - Updated supported tasks and documentation
  8. genai_bench/user/openai_user.py - Updated supported tasks mapping
  9. tests/cli/test_validation.py - Updated test cases
  10. tests/sampling/test_base.py - Updated test cases
  11. tests/data/loaders/test_factory.py - Updated test cases