### PR TITLE
feat: Support flexible plot configuration

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -482,7 +482,7 @@ genai-bench excel --experiment-folder <path-to-experiment-folder> --excel-name <
 
 ## Generate a 2x4 Plot
 
-You can check out `genai-bench plot --help` to find how to generate a 2x3 Plot containing:
+You can check out `genai-bench plot --help` to find how to generate a 2x4 Plot containing:
 
 1. Output Inference Speed (tokens/s) vs Output Throughput of Server (tokens/s)
 2. TTFT (s) vs Output Throughput of Server (tokens/s)
@@ -492,6 +492,8 @@ You can check out `genai-bench plot --help` to find how to generate a 2x3 Plot c
 6. TTFT (s) vs Total Throughput (Input + Output) of Server (tokens/s)
 7. P90 E2E Latency (s) per Request vs RPS
 8. P99 E2E Latency (s) per Request vs RPS
+
+**Note**: TTFT plots automatically use logarithmic scale for better visualization of the wide range of values. You can override this by specifying `"y_scale": "linear"` in custom plot configurations.
 
 ```shell
 genai-bench plot --experiments-folder <path-to-experiment-folder> --group-key traffic_scenario

--- a/examples/plot_configs/README.md
+++ b/examples/plot_configs/README.md
@@ -12,10 +12,15 @@ genai-bench plot --experiments-folder /path/to/experiments \
                  --group-key traffic_scenario \
                  --plot-config examples/plot_configs/custom_2x2.json
 
-# Use a built-in preset
+# Use a built-in preset for multiple scenarios
 genai-bench plot --experiments-folder /path/to/experiments \
                  --group-key traffic_scenario \
                  --preset simple_2x2
+
+# Use multi-line preset for single scenario analysis
+genai-bench plot --experiments-folder /path/to/experiments \
+                 --group-key none \
+                 --preset single_scenario_analysis
 
 # List available fields with actual data from your experiment
 genai-bench plot --experiments-folder /path/to/experiments \
@@ -47,10 +52,24 @@ A comprehensive 2x3 grid for detailed performance analysis:
 - Request success rates
 - Throughput scaling
 
+### multi_line_latency.json
+Demonstrates multi-line plotting capabilities with a 2x2 layout:
+- **Latency Percentiles Comparison**: Multiple latency percentiles (mean, P90, P99) on one plot
+- **TTFT Performance Analysis**: Mean and P95 TTFT comparison
+- **Token Processing Speed**: Output speed vs input throughput comparison
+- **Request Success Metrics**: Single-line error rate plot
+
+### comprehensive_multi_line.json
+Advanced multi-line example with 1x3 layout showcasing complex comparisons:
+- **E2E Latency Distribution**: All percentiles (P25, P50, P75, P90, P99) with custom colors
+- **Throughput Components**: Input, output, and total throughput comparison
+- **Token Statistics**: Input, output, and total token counts as scatter plot
+
 ## Configuration Format
 
 Plot configurations use the following JSON schema:
 
+### Single-Line Plots
 ```json
 {
   "layout": {
@@ -62,14 +81,79 @@ Plot configurations use the following JSON schema:
     {
       "title": "Plot Title",
       "x_field": "field.path.from.AggregatedMetrics",
-      "y_field": "another.field.path",
-      "x_label": "Custom X Label",  // Optional
-      "y_label": "Custom Y Label",  // Optional
-      "plot_type": "line",  // line, scatter, or bar
-      "position": [0, 0]    // [row, col] in grid
+      "y_field": "another.field.path",           // Single field
+      "x_label": "Custom X Label",              // Optional
+      "y_label": "Custom Y Label",              // Optional
+      "plot_type": "line",                      // line, scatter, or bar
+      "position": [0, 0]                        // [row, col] in grid
     }
   ]
 }
+```
+
+### Multi-Line Plots
+```json
+{
+  "plots": [
+    {
+      "title": "Multi-Line Comparison",
+      "x_field": "requests_per_second",
+      "y_fields": [                             // Multiple fields on same plot
+        {
+          "field": "stats.e2e_latency.mean",
+          "label": "Mean Latency",              // Optional custom label
+          "color": "blue",                      // Optional custom color
+          "linestyle": "-"                      // Optional: '-', '--', '-.', ':'
+        },
+        {
+          "field": "stats.e2e_latency.p90",
+          "label": "P90 Latency",
+          "color": "red",
+          "linestyle": "--"
+        }
+      ],
+      "x_label": "RPS",
+      "y_label": "Latency (s)",
+      "plot_type": "line",
+      "position": [0, 0]
+    }
+  ]
+}
+```
+
+### Key Features
+
+- **Single vs Multi-Line**: Use `y_field` for single line, `y_fields` for multiple lines
+- **Custom Styling**: Each line can have custom color, linestyle, and label
+- **Flexible Layout**: Any NxM grid layout from 1x1 to 5x6
+- **Plot Types**: `line`, `scatter`, `bar` (multi-line bar creates grouped bars)
+- **Automatic Legends**: Multi-line plots automatically generate legends
+
+### When to Use Multi-Line Plots
+
+✅ **GOOD Use Cases:**
+- **Single scenario analysis**: Use `--group-key ""` (empty string) for one traffic scenario
+- **Deep metric comparison**: Comparing mean, P90, P99 latency on same plot
+- **Performance analysis**: Related metrics on the same scale
+
+❌ **AVOID Multi-Line Plots When:**
+- **Multiple scenarios**: `--group-key traffic_scenario` with multiple scenarios
+- **Multiple server versions**: `--group-key server_version`
+- **Any grouping**: Multi-line + grouping creates cluttered, hard-to-read plots
+
+The system will automatically convert multi-line plots to single-line plots when it detects multiple groups/scenarios for better visualization.
+
+### Usage Patterns
+
+```bash
+# ✅ GOOD: Multi-line for single scenario analysis
+genai-bench plot --preset single_scenario_analysis --group-key ""
+
+# ✅ GOOD: Single-line for multiple scenarios
+genai-bench plot --preset 2x4_default --group-key traffic_scenario
+
+# ⚠️ AUTO-CONVERTED: Multi-line + grouping → single-line
+genai-bench plot --preset multi_line_latency --group-key traffic_scenario
 ```
 
 ## Available Fields

--- a/examples/plot_configs/README.md
+++ b/examples/plot_configs/README.md
@@ -1,0 +1,123 @@
+# Plot Configuration Examples
+
+This directory contains example plot configurations for the flexible plotting system in genai-bench.
+
+## Usage
+
+Use these configurations with the `genai-bench plot` command:
+
+```bash
+# Use a custom configuration file
+genai-bench plot --experiments-folder /path/to/experiments \
+                 --group-key traffic_scenario \
+                 --plot-config examples/plot_configs/custom_2x2.json
+
+# Use a built-in preset
+genai-bench plot --experiments-folder /path/to/experiments \
+                 --group-key traffic_scenario \
+                 --preset simple_2x2
+
+# List available fields with actual data from your experiment
+genai-bench plot --experiments-folder /path/to/experiments \
+                 --group-key traffic_scenario \
+                 --list-fields
+
+# Validate a configuration without generating plots
+genai-bench plot --experiments-folder /path/to/experiments \
+                 --group-key traffic_scenario \
+                 --plot-config examples/plot_configs/custom_2x2.json \
+                 --validate-only
+```
+
+## Available Configurations
+
+### custom_2x2.json
+A simple 2x2 grid layout focusing on key performance metrics:
+- Throughput vs Mean Latency
+- RPS vs P99 Latency
+- Concurrency vs TTFT
+- Error Rate Analysis
+
+### performance_focused.json
+A comprehensive 2x3 grid for detailed performance analysis:
+- Token generation speed analysis
+- Time to first token trends
+- Latency percentiles
+- Token efficiency scatter plot
+- Request success rates
+- Throughput scaling
+
+## Configuration Format
+
+Plot configurations use the following JSON schema:
+
+```json
+{
+  "layout": {
+    "rows": 2,
+    "cols": 2,
+    "figsize": [16, 12]  // Optional: [width, height] in inches
+  },
+  "plots": [
+    {
+      "title": "Plot Title",
+      "x_field": "field.path.from.AggregatedMetrics",
+      "y_field": "another.field.path",
+      "x_label": "Custom X Label",  // Optional
+      "y_label": "Custom Y Label",  // Optional
+      "plot_type": "line",  // line, scatter, or bar
+      "position": [0, 0]    // [row, col] in grid
+    }
+  ]
+}
+```
+
+## Available Fields
+
+Run `genai-bench plot --experiments-folder /path/to/experiments --group-key traffic_scenario --list-fields` to see all available field paths with actual data from your experiments.
+
+Common field paths include:
+
+### Direct Metrics
+- `num_concurrency` - Concurrency level
+- `requests_per_second` - RPS
+- `error_rate` - Error rate
+- `mean_output_throughput_tokens_per_s` - Server output throughput
+- `mean_total_tokens_throughput_tokens_per_s` - Total throughput
+- `run_duration` - Duration of the run
+
+### Statistical Fields
+Access statistics using `stats.{metric}.{statistic}`:
+
+**Metrics:** ttft, tpot, e2e_latency, output_latency, output_inference_speed, num_input_tokens, num_output_tokens, total_tokens, input_throughput, output_throughput
+
+**Statistics:** min, max, mean, stddev, sum, p25, p50, p75, p90, p95, p99
+
+**Examples:**
+- `stats.ttft.mean` - Mean time to first token
+- `stats.e2e_latency.p99` - 99th percentile end-to-end latency
+- `stats.output_inference_speed.mean` - Mean output inference speed
+
+## Built-in Presets
+
+### 2x4_default
+The original 2x4 layout with all 8 standard plots. This maintains backwards compatibility with the existing plotting system.
+
+### simple_2x2
+A simplified 2x2 layout with the most important metrics for quick analysis.
+
+## Creating Custom Configurations
+
+1. Start with an example configuration
+2. Modify the layout dimensions and plot specifications
+3. Use `--list-fields` to find available metrics
+4. Use `--validate-only` to test your configuration
+5. Generate plots with your custom config
+
+## Tips
+
+- Use descriptive titles for your plots
+- Choose appropriate plot types (line for trends, scatter for relationships, bar for comparisons)
+- Ensure field paths are valid using `--validate-only`
+- Consider your audience when selecting metrics to display
+- Use figsize to adjust the output image dimensions

--- a/examples/plot_configs/comprehensive_multi_line.json
+++ b/examples/plot_configs/comprehensive_multi_line.json
@@ -1,0 +1,99 @@
+{
+  "layout": {
+    "rows": 1,
+    "cols": 3,
+    "figsize": [24, 8]
+  },
+  "plots": [
+    {
+      "title": "End-to-End Latency Distribution",
+      "x_field": "requests_per_second",
+      "y_fields": [
+        {
+          "field": "stats.e2e_latency.p25",
+          "label": "P25",
+          "color": "#1f77b4",
+          "linestyle": "-"
+        },
+        {
+          "field": "stats.e2e_latency.p50",
+          "label": "P50 (Median)",
+          "color": "#ff7f0e",
+          "linestyle": "-"
+        },
+        {
+          "field": "stats.e2e_latency.p75",
+          "label": "P75",
+          "color": "#2ca02c",
+          "linestyle": "-"
+        },
+        {
+          "field": "stats.e2e_latency.p90",
+          "label": "P90",
+          "color": "#d62728",
+          "linestyle": "--"
+        },
+        {
+          "field": "stats.e2e_latency.p99",
+          "label": "P99",
+          "color": "#9467bd",
+          "linestyle": "-."
+        }
+      ],
+      "x_label": "RPS",
+      "y_label": "E2E Latency (s)",
+      "plot_type": "line",
+      "position": [0, 0]
+    },
+    {
+      "title": "Throughput Components",
+      "x_field": "num_concurrency",
+      "y_fields": [
+        {
+          "field": "mean_input_throughput_tokens_per_s",
+          "label": "Input Throughput",
+          "color": "skyblue"
+        },
+        {
+          "field": "mean_output_throughput_tokens_per_s",
+          "label": "Output Throughput",
+          "color": "lightcoral"
+        },
+        {
+          "field": "mean_total_tokens_throughput_tokens_per_s",
+          "label": "Total Throughput",
+          "color": "lightgreen"
+        }
+      ],
+      "x_label": "Concurrency",
+      "y_label": "Throughput (tokens/s)",
+      "plot_type": "line",
+      "position": [0, 1]
+    },
+    {
+      "title": "Token Statistics",
+      "x_field": "requests_per_second",
+      "y_fields": [
+        {
+          "field": "stats.num_input_tokens.mean",
+          "label": "Avg Input Tokens",
+          "color": "navy"
+        },
+        {
+          "field": "stats.num_output_tokens.mean",
+          "label": "Avg Output Tokens",
+          "color": "darkred"
+        },
+        {
+          "field": "stats.total_tokens.mean",
+          "label": "Avg Total Tokens",
+          "color": "darkgreen"
+        }
+      ],
+      "x_label": "RPS",
+      "y_label": "Token Count",
+      "plot_type": "scatter",
+      "position": [0, 2]
+    }
+  ]
+}

--- a/examples/plot_configs/custom_2x2.json
+++ b/examples/plot_configs/custom_2x2.json
@@ -1,0 +1,45 @@
+{
+  "layout": {
+    "rows": 2,
+    "cols": 2,
+    "figsize": [16, 12]
+  },
+  "plots": [
+    {
+      "title": "Throughput vs Mean Latency",
+      "x_field": "mean_output_throughput_tokens_per_s",
+      "y_field": "stats.e2e_latency.mean",
+      "x_label": "Output Throughput (tokens/s)",
+      "y_label": "Mean E2E Latency (s)",
+      "plot_type": "line",
+      "position": [0, 0]
+    },
+    {
+      "title": "RPS vs P99 Latency",
+      "x_field": "requests_per_second",
+      "y_field": "stats.e2e_latency.p99",
+      "x_label": "Requests Per Second",
+      "y_label": "P99 E2E Latency (s)",
+      "plot_type": "line",
+      "position": [0, 1]
+    },
+    {
+      "title": "Concurrency vs TTFT",
+      "x_field": "num_concurrency",
+      "y_field": "stats.ttft.mean",
+      "x_label": "Concurrency Level",
+      "y_label": "Mean TTFT (s)",
+      "plot_type": "line",
+      "position": [1, 0]
+    },
+    {
+      "title": "Error Rate Analysis",
+      "x_field": "num_concurrency",
+      "y_field": "error_rate",
+      "x_label": "Concurrency Level",
+      "y_label": "Error Rate",
+      "plot_type": "bar",
+      "position": [1, 1]
+    }
+  ]
+}

--- a/examples/plot_configs/multi_line_latency.json
+++ b/examples/plot_configs/multi_line_latency.json
@@ -1,0 +1,84 @@
+{
+  "layout": {
+    "rows": 2,
+    "cols": 2,
+    "figsize": [16, 12]
+  },
+  "plots": [
+    {
+      "title": "Latency Percentiles Comparison",
+      "x_field": "requests_per_second",
+      "y_fields": [
+        {
+          "field": "stats.e2e_latency.mean",
+          "label": "Mean Latency",
+          "color": "blue",
+          "linestyle": "-"
+        },
+        {
+          "field": "stats.e2e_latency.p90",
+          "label": "P90 Latency",
+          "color": "orange",
+          "linestyle": "--"
+        },
+        {
+          "field": "stats.e2e_latency.p99",
+          "label": "P99 Latency",
+          "color": "red",
+          "linestyle": "-."
+        }
+      ],
+      "x_label": "Requests Per Second",
+      "y_label": "Latency (seconds)",
+      "plot_type": "line",
+      "position": [0, 0]
+    },
+    {
+      "title": "TTFT Performance Analysis",
+      "x_field": "mean_output_throughput_tokens_per_s",
+      "y_fields": [
+        {
+          "field": "stats.ttft.mean",
+          "label": "Mean TTFT",
+          "color": "green"
+        },
+        {
+          "field": "stats.ttft.p95",
+          "label": "P95 TTFT",
+          "color": "purple"
+        }
+      ],
+      "x_label": "Output Throughput (tokens/s)",
+      "y_label": "Time to First Token (s)",
+      "plot_type": "line",
+      "position": [0, 1]
+    },
+    {
+      "title": "Token Processing Speed",
+      "x_field": "num_concurrency",
+      "y_fields": [
+        {
+          "field": "stats.output_inference_speed.mean",
+          "label": "Output Speed"
+        },
+        {
+          "field": "stats.input_throughput.mean",
+          "label": "Input Throughput"
+        }
+      ],
+      "x_label": "Concurrency Level",
+      "y_label": "Speed (tokens/s)",
+      "plot_type": "line",
+      "position": [1, 0]
+    },
+    {
+      "title": "Request Success Metrics",
+      "x_field": "num_concurrency",
+      "y_field": "error_rate",
+      "x_label": "Concurrency Level",
+      "y_label": "Error Rate",
+      "plot_type": "bar",
+      "position": [1, 1]
+    }
+  ]
+}

--- a/examples/plot_configs/multi_line_latency.json
+++ b/examples/plot_configs/multi_line_latency.json
@@ -49,9 +49,10 @@
         }
       ],
       "x_label": "Output Throughput (tokens/s)",
-      "y_label": "Time to First Token (s)",
+      "y_label": "Time to First Token (s) (log scale)",
       "plot_type": "line",
-      "position": [0, 1]
+      "position": [0, 1],
+      "y_scale": "log"
     },
     {
       "title": "Token Processing Speed",

--- a/examples/plot_configs/performance_focused.json
+++ b/examples/plot_configs/performance_focused.json
@@ -1,0 +1,63 @@
+{
+  "layout": {
+    "rows": 2,
+    "cols": 3,
+    "figsize": [24, 12]
+  },
+  "plots": [
+    {
+      "title": "Token Generation Speed",
+      "x_field": "mean_output_throughput_tokens_per_s",
+      "y_field": "stats.output_inference_speed.mean",
+      "x_label": "Server Output Throughput (tokens/s)",
+      "y_label": "Per-Request Speed (tokens/s)",
+      "plot_type": "line",
+      "position": [0, 0]
+    },
+    {
+      "title": "Time to First Token",
+      "x_field": "mean_output_throughput_tokens_per_s",
+      "y_field": "stats.ttft.mean",
+      "x_label": "Server Output Throughput (tokens/s)",
+      "y_label": "TTFT (s)",
+      "plot_type": "line",
+      "position": [0, 1]
+    },
+    {
+      "title": "Latency Percentiles",
+      "x_field": "requests_per_second",
+      "y_field": "stats.e2e_latency.p90",
+      "x_label": "RPS",
+      "y_label": "P90 Latency (s)",
+      "plot_type": "line",
+      "position": [0, 2]
+    },
+    {
+      "title": "Token Efficiency",
+      "x_field": "stats.num_input_tokens.mean",
+      "y_field": "stats.num_output_tokens.mean",
+      "x_label": "Mean Input Tokens",
+      "y_label": "Mean Output Tokens",
+      "plot_type": "scatter",
+      "position": [1, 0]
+    },
+    {
+      "title": "Request Success Rate",
+      "x_field": "num_concurrency",
+      "y_field": "num_completed_requests",
+      "x_label": "Concurrency",
+      "y_label": "Completed Requests",
+      "plot_type": "bar",
+      "position": [1, 1]
+    },
+    {
+      "title": "Throughput Scaling",
+      "x_field": "num_concurrency",
+      "y_field": "mean_total_tokens_throughput_tokens_per_s",
+      "x_label": "Concurrency",
+      "y_label": "Total Throughput (tokens/s)",
+      "plot_type": "line",
+      "position": [1, 2]
+    }
+  ]
+}

--- a/genai_bench/analysis/flexible_plot_report.py
+++ b/genai_bench/analysis/flexible_plot_report.py
@@ -462,10 +462,17 @@ class FlexiblePlotGenerator:
         # Position legend outside plot area for multi-line plots to avoid overlap
         ax.legend(bbox_to_anchor=(1.05, 1), loc="upper left", fontsize="small")
 
-        # Apply any special formatting
-        y_field_specs = plot_spec.get_y_field_specs()
-        if any("ttft" in spec.field.lower() for spec in y_field_specs):
-            ax.set_yscale("log", base=10)
+        # Apply y-axis scale from config or default based on field name
+        if plot_spec.y_scale:
+            # Use explicit scale from config
+            if plot_spec.y_scale == "log":
+                ax.set_yscale("log", base=10)
+            # 'linear' is matplotlib default, no need to set explicitly
+        else:
+            # Backward compatibility: apply log scale for TTFT fields if not specified
+            y_field_specs = plot_spec.get_y_field_specs()
+            if any("ttft" in spec.field.lower() for spec in y_field_specs):
+                ax.set_yscale("log", base=10)
 
         # Handle concurrency x-axis formatting - evenly spaced ticks
         if plot_spec.x_field == "num_concurrency":

--- a/genai_bench/analysis/flexible_plot_report.py
+++ b/genai_bench/analysis/flexible_plot_report.py
@@ -1,0 +1,323 @@
+"""Flexible plotting system supporting user-defined plot configurations."""
+
+import os
+from typing import Any, Dict, List, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+
+from genai_bench.analysis.experiment_loader import ExperimentMetrics, MetricsData
+from genai_bench.analysis.plot_config import PlotConfig, PlotConfigManager, PlotSpec
+from genai_bench.analysis.plot_report import plot_error_rates, plot_graph
+from genai_bench.logging import init_logger
+from genai_bench.protocol import ExperimentMetadata
+from genai_bench.utils import sanitize_string
+
+logger = init_logger(__name__)
+
+
+class FlexiblePlotGenerator:
+    """Generate plots based on flexible configuration."""
+
+    def __init__(self, config: PlotConfig):
+        self.config = config
+
+    def generate_plots(
+        self,
+        run_data_list: List[Tuple[ExperimentMetadata, ExperimentMetrics]],
+        group_key: str,
+        experiment_folder: str,
+    ) -> None:
+        """Generate plots based on configuration."""
+        if group_key == "traffic_scenario":
+            self._plot_by_scenario(run_data_list, experiment_folder)
+        else:
+            self._plot_by_group(run_data_list, group_key, experiment_folder)
+
+    def _plot_by_scenario(
+        self,
+        run_data_list: List[Tuple[ExperimentMetadata, ExperimentMetrics]],
+        experiment_folder: str,
+    ) -> None:
+        """Plot grouped by traffic scenario."""
+        from genai_bench.analysis.plot_report import get_scenario_data
+
+        label_to_concurrency_map, concurrency_data_list, labels = get_scenario_data(
+            run_data_list
+        )
+
+        fig, axs = self._create_figure()
+        fig.suptitle("Grouped by Traffic Scenario", fontsize=14)
+
+        self._plot_metrics(axs, concurrency_data_list, label_to_concurrency_map, labels)
+        self._finalize_and_save_plots(
+            axs, fig, labels, experiment_folder, "traffic_scenario"
+        )
+
+    def _plot_by_group(
+        self,
+        run_data_list: List[Tuple[ExperimentMetadata, ExperimentMetrics]],
+        group_key: str,
+        experiment_folder: str,
+    ) -> None:
+        """Plot grouped by specified group key."""
+        from genai_bench.analysis.plot_report import (
+            extract_traffic_scenarios,
+            get_group_data,
+        )
+
+        traffic_scenarios = extract_traffic_scenarios(run_data_list)
+        for traffic_scenario in traffic_scenarios:
+            fig, axs = self._create_figure()
+            fig.suptitle(f"Traffic Scenario: {traffic_scenario}", fontsize=14)
+
+            label_to_concurrency_map, concurrency_data_list, labels = get_group_data(
+                run_data_list, traffic_scenario, group_key
+            )
+
+            self._plot_metrics(
+                axs, concurrency_data_list, label_to_concurrency_map, labels
+            )
+            self._finalize_and_save_plots(
+                axs,
+                fig,
+                labels,
+                experiment_folder,
+                f"{sanitize_string(traffic_scenario)}_group_by_{group_key}",
+            )
+
+    def _create_figure(self) -> Tuple[Figure, Any]:
+        """Create figure with configured layout."""
+        layout = self.config.layout
+        figsize = layout.figsize or (8 * layout.cols, 6 * layout.rows)
+
+        fig, axs = plt.subplots(layout.rows, layout.cols, figsize=figsize)
+
+        # Ensure axs is always 2D array for consistent indexing
+        if layout.rows == 1 and layout.cols == 1:
+            axs = np.array([[axs]])
+        elif layout.rows == 1:
+            axs = axs.reshape(1, -1)
+        elif layout.cols == 1:
+            axs = axs.reshape(-1, 1)
+
+        return fig, axs
+
+    def _plot_metrics(
+        self,
+        axs: Any,
+        concurrency_data_list: List[Dict[int, MetricsData]],
+        label_to_concurrency_map: Dict[str, List[int]],
+        labels: List[str],
+    ) -> None:
+        """Plot metrics based on configuration."""
+        for i, concurrency_data in enumerate(concurrency_data_list):
+            concurrency_levels = label_to_concurrency_map[labels[i]]
+
+            for plot_spec in self.config.plots:
+                self._plot_single_metric(
+                    plot_spec=plot_spec,
+                    ax=axs[plot_spec.position[0], plot_spec.position[1]],
+                    concurrency_data=concurrency_data,
+                    concurrency_levels=concurrency_levels,
+                    label=labels[i],
+                )
+
+    def _plot_single_metric(
+        self,
+        plot_spec: PlotSpec,
+        ax: Axes,
+        concurrency_data: Dict[int, MetricsData],
+        concurrency_levels: List[int],
+        label: str,
+    ) -> None:
+        """Plot a single metric based on plot specification."""
+        try:
+            # Extract data using field paths
+            x_data = []
+            y_data = []
+            valid_concurrency = []
+
+            for c in concurrency_levels:
+                try:
+                    metrics = concurrency_data[c]["aggregated_metrics"]
+
+                    x_val = PlotConfigManager.get_field_value(
+                        metrics, plot_spec.x_field
+                    )
+                    y_val = PlotConfigManager.get_field_value(
+                        metrics, plot_spec.y_field
+                    )
+
+                    if x_val is not None and y_val is not None:
+                        x_data.append(x_val)
+                        y_data.append(y_val)
+                        valid_concurrency.append(c)
+
+                except (AttributeError, KeyError) as e:
+                    logger.warning(f"Missing data for concurrency {c}: {e}")
+                    continue
+
+            if not x_data or not y_data:
+                logger.warning(f"No valid data for plot: {plot_spec.title}")
+                return
+
+            # Handle special error rate plot
+            if plot_spec.y_field == "error_rate" and plot_spec.plot_type == "bar":
+                plot_error_rates(ax, concurrency_data, concurrency_levels, label)
+            else:
+                # Use existing plot_graph function
+                plot_graph(
+                    ax=ax,
+                    x_data=x_data,
+                    y_data=y_data,
+                    x_label=plot_spec.x_label
+                    or self._generate_label(plot_spec.x_field),
+                    y_label=plot_spec.y_label
+                    or self._generate_label(plot_spec.y_field),
+                    title=plot_spec.title,
+                    concurrency_levels=valid_concurrency,
+                    label=label,
+                    plot_type=plot_spec.plot_type,
+                )
+
+        except Exception as e:
+            logger.error(f"Error plotting {plot_spec.title}: {e}")
+            ax.text(
+                0.5,
+                0.5,
+                f"Error: {str(e)}",
+                ha="center",
+                va="center",
+                transform=ax.transAxes,
+            )
+
+    def _generate_label(self, field_path: str) -> str:
+        """Generate a human-readable label from field path."""
+        # Simple label generation - can be enhanced
+        parts = field_path.split(".")
+        if len(parts) == 1:
+            return field_path.replace("_", " ").title()
+
+        # Handle stats fields
+        if parts[0] == "stats":
+            metric = parts[1].replace("_", " ").title()
+            if len(parts) > 2:
+                stat = parts[2].upper()
+                return f"{metric} ({stat})"
+            return metric
+
+        return field_path.replace("_", " ").title()
+
+    def _finalize_and_save_plots(
+        self,
+        axs: Any,
+        fig: Figure,
+        labels: List[str],
+        experiment_folder: str,
+        output_file_prefix: str,
+    ) -> None:
+        """Finalize and save plots."""
+        from genai_bench.analysis.plot_report import save_individual_subplots
+
+        # Hide unused subplots
+        layout = self.config.layout
+        used_positions = {plot.position for plot in self.config.plots}
+
+        for row in range(layout.rows):
+            for col in range(layout.cols):
+                if (row, col) not in used_positions:
+                    axs[row, col].set_visible(False)
+
+        # Save individual subplots
+        save_individual_subplots(axs, experiment_folder, output_file_prefix)
+
+        # Add legend and save combined plot
+        fig.legend(labels=labels, loc="lower center", ncol=3, fancybox=True)
+        plt.tight_layout()
+        plt.subplots_adjust(bottom=0.1)
+
+        output_file = os.path.join(
+            experiment_folder,
+            f"{output_file_prefix}_combined_plots_{layout.rows}x{layout.cols}.png",
+        )
+        logger.info(f"🎨 Saving {output_file}")
+        plt.savefig(output_file)
+        plt.close()
+
+
+def plot_experiment_data_flexible(
+    run_data_list: List[Tuple[ExperimentMetadata, ExperimentMetrics]],
+    group_key: str,
+    experiment_folder: str,
+    plot_config: PlotConfig = None,
+) -> None:
+    """
+    Plot experiment data using flexible configuration.
+
+    Args:
+        run_data_list: List of experiment data tuples
+        group_key: Key to group data by
+        experiment_folder: Output folder path
+        plot_config: Plot configuration (uses default if None)
+    """
+    if plot_config is None:
+        plot_config = PlotConfigManager.load_preset("2x4_default")
+
+    generator = FlexiblePlotGenerator(plot_config)
+    generator.generate_plots(run_data_list, group_key, experiment_folder)
+
+
+def validate_plot_config_with_data(
+    config: PlotConfig,
+    sample_metrics: List[Tuple[ExperimentMetadata, ExperimentMetrics]],
+) -> List[str]:
+    """
+    Validate plot configuration against actual data.
+
+    Returns:
+        List of validation error messages (empty if valid)
+    """
+    errors = []
+
+    if not sample_metrics:
+        errors.append("No sample data provided for validation")
+        return errors
+
+    # Get a sample aggregated metrics object
+    try:
+        _, experiment_metrics = sample_metrics[0]
+        first_scenario = list(experiment_metrics.keys())[0]
+        first_concurrency = list(experiment_metrics[first_scenario].keys())[0]
+        sample_agg_metrics = experiment_metrics[first_scenario][first_concurrency][
+            "aggregated_metrics"
+        ]
+    except (IndexError, KeyError) as e:
+        errors.append(f"Cannot extract sample metrics for validation: {e}")
+        return errors
+
+    # Validate each plot specification
+    for i, plot_spec in enumerate(config.plots):
+        # Validate field paths
+        if not PlotConfigManager.validate_field_path(
+            plot_spec.x_field, sample_agg_metrics
+        ):
+            errors.append(f"Plot {i+1}: Invalid x_field '{plot_spec.x_field}'")
+
+        if not PlotConfigManager.validate_field_path(
+            plot_spec.y_field, sample_agg_metrics
+        ):
+            errors.append(f"Plot {i+1}: Invalid y_field '{plot_spec.y_field}'")
+
+        # Validate position bounds
+        layout = config.layout
+        row, col = plot_spec.position
+        if row >= layout.rows or col >= layout.cols:
+            errors.append(
+                f"Plot {i+1}: Position ({row}, {col}) exceeds layout bounds "
+                f"({layout.rows-1}, {layout.cols-1})"
+            )
+
+    return errors

--- a/genai_bench/analysis/flexible_plot_report.py
+++ b/genai_bench/analysis/flexible_plot_report.py
@@ -31,10 +31,50 @@ class FlexiblePlotGenerator:
         experiment_folder: str,
     ) -> None:
         """Generate plots based on configuration."""
-        if group_key == "traffic_scenario":
+        if group_key == "none":
+            self._plot_single_analysis(run_data_list, experiment_folder)
+        elif group_key == "traffic_scenario":
             self._plot_by_scenario(run_data_list, experiment_folder)
         else:
             self._plot_by_group(run_data_list, group_key, experiment_folder)
+
+    def _plot_single_analysis(
+        self,
+        run_data_list: List[Tuple[ExperimentMetadata, ExperimentMetrics]],
+        experiment_folder: str,
+    ) -> None:
+        """Plot for single scenario analysis without grouping - plots ALL scenarios."""
+        if not run_data_list:
+            logger.warning("No experiment data found for single analysis")
+            return
+
+        # Get the first experiment
+        metadata, experiment_metrics = run_data_list[0]
+        all_scenarios = list(experiment_metrics.keys())
+
+        logger.info(
+            f"Single scenario analysis mode - plotting all {len(all_scenarios)} "
+            f"scenarios: {all_scenarios}"
+        )
+
+        # Plot each scenario individually for clean multi-line analysis
+        for scenario in all_scenarios:
+            concurrency_data = experiment_metrics[scenario]
+            concurrency_levels = sorted(concurrency_data.keys())
+
+            fig, axs = self._create_figure()
+            fig.suptitle(f"Single Scenario Analysis: {scenario}", fontsize=14)
+
+            # Single scenario = no grouping, perfect for multi-line plots
+            # Pass empty label since we're not grouping
+            self._plot_metrics(axs, [concurrency_data], {"": concurrency_levels}, [""])
+            self._finalize_and_save_plots(
+                axs,
+                fig,
+                [""],
+                experiment_folder,
+                f"single_analysis_{sanitize_string(scenario)}",
+            )
 
     def _plot_by_scenario(
         self,
@@ -113,6 +153,22 @@ class FlexiblePlotGenerator:
         labels: List[str],
     ) -> None:
         """Plot metrics based on configuration."""
+        # Check if we have multi-line plots with multiple scenarios/groups
+        has_multi_line = any(plot.is_multi_line() for plot in self.config.plots)
+        has_multiple_groups = len(labels) > 1
+
+        if has_multi_line and has_multiple_groups:
+            logger.warning(
+                f"Multi-line plots detected with {len(labels)} groups/scenarios. "
+                f"Multi-line plots work best with single scenarios. "
+                f"Converting to single-line plots for better visualization."
+            )
+            # Convert multi-line plots to single-line plots automatically
+            self._plot_metrics_single_line_fallback(
+                axs, concurrency_data_list, label_to_concurrency_map, labels
+            )
+            return
+
         for i, concurrency_data in enumerate(concurrency_data_list):
             concurrency_levels = label_to_concurrency_map[labels[i]]
 
@@ -125,6 +181,59 @@ class FlexiblePlotGenerator:
                     label=labels[i],
                 )
 
+    def _plot_metrics_single_line_fallback(
+        self,
+        axs: Any,
+        concurrency_data_list: List[Dict[int, MetricsData]],
+        label_to_concurrency_map: Dict[str, List[int]],
+        labels: List[str],
+    ) -> None:
+        """Fallback to single-line plotting when multi-line conflicts with grouping."""
+        logger.info(
+            "Converting multi-line plots to single-line plots for better "
+            "visualization with multiple groups"
+        )
+
+        for i, concurrency_data in enumerate(concurrency_data_list):
+            concurrency_levels = label_to_concurrency_map[labels[i]]
+
+            for plot_spec in self.config.plots:
+                if plot_spec.is_multi_line():
+                    # For multi-line plots, just use the first Y-field
+                    y_field_specs = plot_spec.get_y_field_specs()
+                    first_field = y_field_specs[0]
+
+                    # Create a temporary single-line plot spec
+                    from genai_bench.analysis.plot_config import PlotSpec
+
+                    single_line_spec = PlotSpec(
+                        title=f"{plot_spec.title} "
+                        f"({first_field.label or self._generate_label(first_field.field)})",  # noqa: E501
+                        x_field=plot_spec.x_field,
+                        y_field=first_field.field,
+                        x_label=plot_spec.x_label,
+                        y_label=plot_spec.y_label,
+                        plot_type=plot_spec.plot_type,
+                        position=plot_spec.position,
+                    )
+
+                    self._plot_single_line_metric(
+                        plot_spec=single_line_spec,
+                        ax=axs[plot_spec.position[0], plot_spec.position[1]],
+                        concurrency_data=concurrency_data,
+                        concurrency_levels=concurrency_levels,
+                        label=labels[i],
+                    )
+                else:
+                    # Regular single-line plot
+                    self._plot_single_metric(
+                        plot_spec=plot_spec,
+                        ax=axs[plot_spec.position[0], plot_spec.position[1]],
+                        concurrency_data=concurrency_data,
+                        concurrency_levels=concurrency_levels,
+                        label=labels[i],
+                    )
+
     def _plot_single_metric(
         self,
         plot_spec: PlotSpec,
@@ -135,52 +244,13 @@ class FlexiblePlotGenerator:
     ) -> None:
         """Plot a single metric based on plot specification."""
         try:
-            # Extract data using field paths
-            x_data = []
-            y_data = []
-            valid_concurrency = []
-
-            for c in concurrency_levels:
-                try:
-                    metrics = concurrency_data[c]["aggregated_metrics"]
-
-                    x_val = PlotConfigManager.get_field_value(
-                        metrics, plot_spec.x_field
-                    )
-                    y_val = PlotConfigManager.get_field_value(
-                        metrics, plot_spec.y_field
-                    )
-
-                    if x_val is not None and y_val is not None:
-                        x_data.append(x_val)
-                        y_data.append(y_val)
-                        valid_concurrency.append(c)
-
-                except (AttributeError, KeyError) as e:
-                    logger.warning(f"Missing data for concurrency {c}: {e}")
-                    continue
-
-            if not x_data or not y_data:
-                logger.warning(f"No valid data for plot: {plot_spec.title}")
-                return
-
-            # Handle special error rate plot
-            if plot_spec.y_field == "error_rate" and plot_spec.plot_type == "bar":
-                plot_error_rates(ax, concurrency_data, concurrency_levels, label)
+            if plot_spec.is_multi_line():
+                self._plot_multi_line_metric(
+                    plot_spec, ax, concurrency_data, concurrency_levels, label
+                )
             else:
-                # Use existing plot_graph function
-                plot_graph(
-                    ax=ax,
-                    x_data=x_data,
-                    y_data=y_data,
-                    x_label=plot_spec.x_label
-                    or self._generate_label(plot_spec.x_field),
-                    y_label=plot_spec.y_label
-                    or self._generate_label(plot_spec.y_field),
-                    title=plot_spec.title,
-                    concurrency_levels=valid_concurrency,
-                    label=label,
-                    plot_type=plot_spec.plot_type,
+                self._plot_single_line_metric(
+                    plot_spec, ax, concurrency_data, concurrency_levels, label
                 )
 
         except Exception as e:
@@ -193,6 +263,339 @@ class FlexiblePlotGenerator:
                 va="center",
                 transform=ax.transAxes,
             )
+
+    def _plot_single_line_metric(
+        self,
+        plot_spec: PlotSpec,
+        ax: Axes,
+        concurrency_data: Dict[int, MetricsData],
+        concurrency_levels: List[int],
+        label: str,
+    ) -> None:
+        """Plot a single line metric (original behavior)."""
+        # Extract data using field paths
+        x_data = []
+        y_data = []
+        valid_concurrency = []
+
+        y_field_spec = plot_spec.get_y_field_specs()[0]  # Single field
+
+        for c in concurrency_levels:
+            try:
+                metrics = concurrency_data[c]["aggregated_metrics"]
+
+                x_val = PlotConfigManager.get_field_value(metrics, plot_spec.x_field)
+                y_val = PlotConfigManager.get_field_value(metrics, y_field_spec.field)
+
+                if x_val is not None and y_val is not None:
+                    x_data.append(x_val)
+                    y_data.append(y_val)
+                    valid_concurrency.append(c)
+
+            except (AttributeError, KeyError) as e:
+                logger.warning(f"Missing data for concurrency {c}: {e}")
+                continue
+
+        if not x_data or not y_data:
+            logger.warning(f"No valid data for plot: {plot_spec.title}")
+            return
+
+        # Handle special error rate plot
+        if y_field_spec.field == "error_rate" and plot_spec.plot_type == "bar":
+            plot_error_rates(ax, concurrency_data, concurrency_levels, label)
+        else:
+            # Use existing plot_graph function
+            plot_graph(
+                ax=ax,
+                x_data=x_data,
+                y_data=y_data,
+                x_label=plot_spec.x_label or self._generate_label(plot_spec.x_field),
+                y_label=plot_spec.y_label or self._generate_label(y_field_spec.field),
+                title=plot_spec.title,
+                concurrency_levels=valid_concurrency,
+                label=label,
+                plot_type=plot_spec.plot_type,
+            )
+
+    def _add_plot_annotations(
+        self,
+        ax: Axes,
+        plot_spec: PlotSpec,
+        valid_x: List[float],
+        y_data: List[float],
+        valid_concurrency: List[int],
+    ) -> None:
+        """Add annotations to plot points."""
+        for x_val, y_val, c_val in zip(
+            valid_x, y_data, valid_concurrency, strict=False
+        ):
+            # Show y-value when x-axis is concurrency, otherwise show concurrency
+            if plot_spec.x_field == "num_concurrency":
+                annotation_text = f"{y_val:.2f}"
+            else:
+                annotation_text = f"{c_val}"
+
+            ax.annotate(
+                annotation_text,
+                (x_val, y_val),
+                fontsize=8,
+                alpha=1.0,
+                xytext=(4, 4),
+                textcoords="offset points",
+                ha="left",
+                bbox=dict(
+                    boxstyle="round,pad=0.2",
+                    facecolor="white",
+                    alpha=0.7,
+                    edgecolor="none",
+                ),
+            )
+
+    def _plot_multi_line_metric(
+        self,
+        plot_spec: PlotSpec,
+        ax: Axes,
+        concurrency_data: Dict[int, MetricsData],
+        concurrency_levels: List[int],
+        label: str,
+    ) -> None:
+        """Plot multiple lines on the same subplot."""
+        colors = plt.cm.tab10.colors  # Get default color cycle
+        linestyles = ["-", "--", "-.", ":"]
+
+        x_data = []
+        for c in concurrency_levels:
+            try:
+                metrics = concurrency_data[c]["aggregated_metrics"]
+                x_val = PlotConfigManager.get_field_value(metrics, plot_spec.x_field)
+                if x_val is not None:
+                    x_data.append(x_val)
+                else:
+                    x_data.append(None)
+            except (AttributeError, KeyError):
+                x_data.append(None)
+
+        # Plot each Y-field as a separate line
+        for i, y_field_spec in enumerate(plot_spec.get_y_field_specs()):
+            y_data = []
+            valid_x = []
+            valid_concurrency = []
+
+            for j, c in enumerate(concurrency_levels):
+                if x_data[j] is None:
+                    continue
+
+                try:
+                    metrics = concurrency_data[c]["aggregated_metrics"]
+                    y_val = PlotConfigManager.get_field_value(
+                        metrics, y_field_spec.field
+                    )
+
+                    if y_val is not None:
+                        y_data.append(y_val)
+                        # Use evenly spaced positions for concurrency, actual values
+                        # otherwise
+                        if plot_spec.x_field == "num_concurrency":
+                            valid_x.append(j)  # Even spacing: 0, 1, 2, 3...
+                        else:
+                            valid_x.append(x_data[j])  # Actual values
+                        valid_concurrency.append(c)
+
+                except (AttributeError, KeyError) as e:
+                    logger.warning(
+                        f"Missing data for field {y_field_spec.field}, "
+                        f"concurrency {c}: {e}"
+                    )
+                    continue
+
+            if not y_data:
+                logger.warning(f"No valid data for field: {y_field_spec.field}")
+                continue
+
+            # Determine line styling
+            color = y_field_spec.color or colors[i % len(colors)]
+            linestyle = y_field_spec.linestyle or linestyles[i % len(linestyles)]
+            line_label = y_field_spec.label or self._generate_label(y_field_spec.field)
+
+            # For multi-line plots, keep labels clean
+            full_label = line_label
+
+            # Plot the line
+            if plot_spec.plot_type == "line":
+                ax.plot(
+                    valid_x,
+                    y_data,
+                    linestyle=linestyle,
+                    color=color,
+                    marker="o",
+                    label=full_label,
+                    markersize=4,
+                )
+                self._add_plot_annotations(
+                    ax, plot_spec, valid_x, y_data, valid_concurrency
+                )
+            elif plot_spec.plot_type == "scatter":
+                ax.scatter(valid_x, y_data, color=color, label=full_label)
+                self._add_plot_annotations(
+                    ax, plot_spec, valid_x, y_data, valid_concurrency
+                )
+            elif plot_spec.plot_type == "bar":
+                # For bar plots with multiple fields, use grouped bars
+                bar_width = 0.8 / len(plot_spec.get_y_field_specs())
+                x_offset = (
+                    i - len(plot_spec.get_y_field_specs()) / 2 + 0.5
+                ) * bar_width
+                ax.bar(
+                    [x + x_offset for x in valid_x],
+                    y_data,
+                    width=bar_width,
+                    color=color,
+                    label=full_label,
+                )
+
+        # Set labels and title
+        ax.set_xlabel(plot_spec.x_label or self._generate_label(plot_spec.x_field))
+        ax.set_ylabel(plot_spec.y_label or "Value")
+        ax.set_title(plot_spec.title)
+        ax.grid(True, alpha=0.3)
+
+        # Position legend outside plot area for multi-line plots to avoid overlap
+        ax.legend(bbox_to_anchor=(1.05, 1), loc="upper left", fontsize="small")
+
+        # Apply any special formatting
+        y_field_specs = plot_spec.get_y_field_specs()
+        if any("ttft" in spec.field.lower() for spec in y_field_specs):
+            ax.set_yscale("log", base=10)
+
+        # Handle concurrency x-axis formatting - evenly spaced ticks
+        if plot_spec.x_field == "num_concurrency":
+            ax.set_xticks(range(len(concurrency_levels)))
+            ax.set_xticklabels(concurrency_levels)
+
+    def _save_individual_subplots_multiline(
+        self, axs: Any, experiment_folder: str, output_file_prefix: str
+    ) -> None:
+        """
+        Custom subplot saving that properly handles multi-line plots.
+        """
+
+        for ax in axs.flat:
+            title = ax.get_title()
+            if not title:  # Skip empty subplots
+                continue
+
+            sanitized_title = sanitize_string(title)
+
+            fig_temp, ax_temp = plt.subplots(figsize=(10, 6))
+
+            # Copy all line plots with proper styling
+            for line in ax.get_lines():
+                ax_temp.plot(
+                    line.get_xdata(),
+                    line.get_ydata(),
+                    label=line.get_label(),
+                    marker=line.get_marker(),
+                    linestyle=line.get_linestyle(),
+                    color=line.get_color(),
+                    markersize=line.get_markersize(),
+                    alpha=line.get_alpha() or 1.0,
+                )
+
+            # Copy annotations - handle both multi-line and single-line plots
+            # For all plots (multi-line and single-line), copy existing annotations
+            for annotation in ax.texts:
+                # Get the actual xy coordinates the annotation is pointing to
+                xy_coords = (
+                    annotation.xy
+                    if hasattr(annotation, "xy")
+                    else annotation.get_position()
+                )
+
+                # Get the original annotation properties
+                original_xytext = (
+                    annotation.xytext if hasattr(annotation, "xytext") else (4, 4)
+                )
+                original_textcoords = (
+                    annotation.textcoords
+                    if hasattr(annotation, "textcoords")
+                    else "offset points"
+                )
+
+                ax_temp.annotate(
+                    annotation.get_text(),
+                    xy=xy_coords,  # Use the actual data coordinates
+                    fontsize=annotation.get_fontsize(),
+                    ha=annotation.get_ha(),
+                    va=annotation.get_va(),
+                    alpha=annotation.get_alpha() or 1.0,
+                    xytext=original_xytext,
+                    textcoords=original_textcoords,
+                    bbox=dict(
+                        boxstyle="round,pad=0.2",
+                        facecolor="white",
+                        alpha=0.7,
+                        edgecolor="none",
+                    ),
+                )
+
+            # Copy axis properties
+            ax_temp.set_title(title)
+            ax_temp.set_xlabel(ax.get_xlabel())
+            ax_temp.set_ylabel(ax.get_ylabel())
+
+            # Copy ticks and labels
+            ax_temp.set_xticks(ax.get_xticks())
+            ax_temp.set_xticklabels(ax.get_xticklabels())
+            ax_temp.set_yticks(ax.get_yticks())
+            ax_temp.set_yticklabels(ax.get_yticklabels())
+
+            # Copy axis limits
+            ax_temp.set_xlim(ax.get_xlim())
+            ax_temp.set_ylim(ax.get_ylim())
+
+            # Copy scale settings
+            if ax.get_yscale() == "log":
+                ax_temp.set_yscale("log", base=10)
+            if ax.get_xscale() == "log":
+                ax_temp.set_xscale("log", base=10)
+
+            # Copy grid
+            ax_temp.grid(
+                ax.get_xgridlines()[0].get_visible() if ax.get_xgridlines() else True,
+                alpha=0.3,
+            )
+            ax_temp.minorticks_on()
+
+            # Handle legend properly for multi-line plots
+            handles, labels = ax.get_legend_handles_labels()
+            if handles and labels:
+                # Clean up labels and position legend properly
+                cleaned_labels = []
+                for label in labels:
+                    # Remove any scenario prefixes for cleaner individual plots
+                    if " - " in label:
+                        label = label.split(" - ")[-1]
+                    cleaned_labels.append(label)
+
+                ax_temp.legend(
+                    handles,
+                    cleaned_labels,
+                    fontsize="small",
+                    bbox_to_anchor=(1.05, 1),
+                    loc="upper left",
+                )
+
+            plt.tight_layout()
+            # Adjust for external legend
+            if handles and labels:
+                plt.subplots_adjust(right=0.85)
+
+            output_file = os.path.join(
+                experiment_folder, f"{output_file_prefix}_{sanitized_title}.png"
+            )
+            fig_temp.savefig(output_file, bbox_inches="tight")
+            plt.close(fig_temp)
+            logger.info(f"🎨 Saving {output_file}")
 
     def _generate_label(self, field_path: str) -> str:
         """Generate a human-readable label from field path."""
@@ -220,7 +623,6 @@ class FlexiblePlotGenerator:
         output_file_prefix: str,
     ) -> None:
         """Finalize and save plots."""
-        from genai_bench.analysis.plot_report import save_individual_subplots
 
         # Hide unused subplots
         layout = self.config.layout
@@ -231,13 +633,23 @@ class FlexiblePlotGenerator:
                 if (row, col) not in used_positions:
                     axs[row, col].set_visible(False)
 
-        # Save individual subplots
-        save_individual_subplots(axs, experiment_folder, output_file_prefix)
+        # Save individual subplots (custom version for multi-line plots)
+        self._save_individual_subplots_multiline(
+            axs, experiment_folder, output_file_prefix
+        )
 
-        # Add legend and save combined plot
-        fig.legend(labels=labels, loc="lower center", ncol=3, fancybox=True)
-        plt.tight_layout()
-        plt.subplots_adjust(bottom=0.1)
+        # For multi-line plots, legends are already positioned on individual subplots
+        # Only add global legend for single-line plots
+        has_multi_line = any(plot.is_multi_line() for plot in self.config.plots)
+
+        if not has_multi_line:
+            fig.legend(labels=labels, loc="lower center", ncol=3, fancybox=True)
+            plt.tight_layout()
+            plt.subplots_adjust(bottom=0.1)
+        else:
+            plt.tight_layout()
+            # Adjust layout to accommodate external legends
+            plt.subplots_adjust(right=0.85)
 
         output_file = os.path.join(
             experiment_folder,
@@ -300,16 +712,29 @@ def validate_plot_config_with_data(
 
     # Validate each plot specification
     for i, plot_spec in enumerate(config.plots):
-        # Validate field paths
+        # Validate X field path
         if not PlotConfigManager.validate_field_path(
             plot_spec.x_field, sample_agg_metrics
         ):
             errors.append(f"Plot {i+1}: Invalid x_field '{plot_spec.x_field}'")
 
-        if not PlotConfigManager.validate_field_path(
-            plot_spec.y_field, sample_agg_metrics
-        ):
-            errors.append(f"Plot {i+1}: Invalid y_field '{plot_spec.y_field}'")
+        # Validate Y field paths (single or multiple)
+        try:
+            y_field_specs = plot_spec.get_y_field_specs()
+            for j, y_field_spec in enumerate(y_field_specs):
+                if not PlotConfigManager.validate_field_path(
+                    y_field_spec.field, sample_agg_metrics
+                ):
+                    if len(y_field_specs) == 1:
+                        errors.append(
+                            f"Plot {i+1}: Invalid y_field '{y_field_spec.field}'"
+                        )
+                    else:
+                        errors.append(
+                            f"Plot {i+1}: Invalid y_fields[{j}] '{y_field_spec.field}'"
+                        )
+        except Exception as e:
+            errors.append(f"Plot {i+1}: Error validating Y-fields: {e}")
 
         # Validate position bounds
         layout = config.layout

--- a/genai_bench/analysis/plot_config.py
+++ b/genai_bench/analysis/plot_config.py
@@ -1,0 +1,372 @@
+"""Plot configuration system for flexible, user-defined plots."""
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from pydantic import BaseModel, Field, field_validator, validator
+
+from genai_bench.logging import init_logger
+from genai_bench.metrics.metrics import AggregatedMetrics
+
+logger = init_logger(__name__)
+
+
+class PlotSpec(BaseModel):
+    """Specification for a single plot."""
+
+    title: str = Field(..., description="Title of the plot")
+    x_field: str = Field(..., description="Field path for X-axis data")
+    y_field: str = Field(..., description="Field path for Y-axis data")
+    x_label: Optional[str] = Field(None, description="Custom X-axis label")
+    y_label: Optional[str] = Field(None, description="Custom Y-axis label")
+    plot_type: str = Field(
+        default="line", description="Type of plot: line, scatter, bar"
+    )
+    position: Tuple[int, int] = Field(..., description="Position in grid (row, col)")
+
+    @field_validator("plot_type")
+    def validate_plot_type(cls, v):
+        allowed_types = {"line", "scatter", "bar"}
+        if v not in allowed_types:
+            raise ValueError(f"plot_type must be one of {allowed_types}, got {v}")
+        return v
+
+
+class PlotLayout(BaseModel):
+    """Layout configuration for the plot grid."""
+
+    rows: int = Field(default=2, ge=1, le=5, description="Number of rows")
+    cols: int = Field(default=4, ge=1, le=6, description="Number of columns")
+    figsize: Optional[Tuple[int, int]] = Field(
+        None, description="Figure size (width, height)"
+    )
+
+
+class PlotConfig(BaseModel):
+    """Complete plot configuration."""
+
+    layout: PlotLayout = Field(default_factory=PlotLayout)
+    plots: List[PlotSpec] = Field(..., description="List of plot specifications")
+
+    @validator("plots")
+    def validate_plot_positions(cls, v, values):
+        if "layout" not in values:
+            return v
+
+        layout = values["layout"]
+        max_row, max_col = layout.rows - 1, layout.cols - 1
+
+        positions = set()
+        for plot in v:
+            row, col = plot.position
+            if row > max_row or col > max_col:
+                raise ValueError(
+                    f"Plot position ({row}, {col}) exceeds layout bounds "
+                    f"({max_row}, {max_col})"
+                )
+            if plot.position in positions:
+                raise ValueError(f"Duplicate plot position: {plot.position}")
+            positions.add(plot.position)
+
+        return v
+
+
+class PlotConfigManager:
+    """Manager for plot configurations."""
+
+    # Built-in presets
+    PRESETS = {
+        "2x4_default": {
+            "layout": {"rows": 2, "cols": 4, "figsize": [32, 12]},
+            "plots": [
+                {
+                    "title": "Output Inference Speed per Request vs "
+                    "Output Throughput of Server",
+                    "x_field": "mean_output_throughput_tokens_per_s",
+                    "y_field": "stats.output_inference_speed.mean",
+                    "x_label": "Output Throughput of Server (tokens/s)",
+                    "y_label": "Output Inference Speed per Request (tokens/s)",
+                    "plot_type": "line",
+                    "position": [0, 0],
+                },
+                {
+                    "title": "TTFT vs Output Throughput of Server",
+                    "x_field": "mean_output_throughput_tokens_per_s",
+                    "y_field": "stats.ttft.mean",
+                    "x_label": "Output Throughput of Server (tokens/s)",
+                    "y_label": "TTFT",
+                    "plot_type": "line",
+                    "position": [0, 1],
+                },
+                {
+                    "title": "Mean E2E Latency per Request vs RPS",
+                    "x_field": "requests_per_second",
+                    "y_field": "stats.e2e_latency.mean",
+                    "x_label": "RPS (req/s)",
+                    "y_label": "Mean E2E Latency per Request (s)",
+                    "plot_type": "line",
+                    "position": [0, 2],
+                },
+                {
+                    "title": "Error Rates by HTTP Status vs Concurrency",
+                    "x_field": "num_concurrency",
+                    "y_field": "error_rate",
+                    "x_label": "Concurrency",
+                    "y_label": "Error Rate",
+                    "plot_type": "bar",
+                    "position": [0, 3],
+                },
+                {
+                    "title": "Output Inference Speed per Request vs "
+                    "Total Throughput (Input + Output) of Server",
+                    "x_field": "mean_total_tokens_throughput_tokens_per_s",
+                    "y_field": "stats.output_inference_speed.mean",
+                    "x_label": "Total Throughput (Input + Output) of Server (tokens/s)",
+                    "y_label": "Output Inference Speed per Request (tokens/s)",
+                    "plot_type": "line",
+                    "position": [1, 0],
+                },
+                {
+                    "title": "TTFT vs Total Throughput (Input + Output) of Server",
+                    "x_field": "mean_total_tokens_throughput_tokens_per_s",
+                    "y_field": "stats.ttft.mean",
+                    "x_label": "Total Throughput (Input + Output) of Server (tokens/s)",
+                    "y_label": "TTFT",
+                    "plot_type": "line",
+                    "position": [1, 1],
+                },
+                {
+                    "title": "P90 E2E Latency per Request vs RPS",
+                    "x_field": "requests_per_second",
+                    "y_field": "stats.e2e_latency.p90",
+                    "x_label": "RPS (req/s)",
+                    "y_label": "P90 E2E Latency per Request (s)",
+                    "plot_type": "line",
+                    "position": [1, 2],
+                },
+                {
+                    "title": "P99 E2E Latency per Request vs RPS",
+                    "x_field": "requests_per_second",
+                    "y_field": "stats.e2e_latency.p99",
+                    "x_label": "RPS (req/s)",
+                    "y_label": "P99 E2E Latency per Request (s)",
+                    "plot_type": "line",
+                    "position": [1, 3],
+                },
+            ],
+        },
+        "simple_2x2": {
+            "layout": {"rows": 2, "cols": 2, "figsize": [16, 12]},
+            "plots": [
+                {
+                    "title": "Throughput vs Latency",
+                    "x_field": "mean_output_throughput_tokens_per_s",
+                    "y_field": "stats.e2e_latency.mean",
+                    "plot_type": "line",
+                    "position": [0, 0],
+                },
+                {
+                    "title": "RPS vs Error Rate",
+                    "x_field": "requests_per_second",
+                    "y_field": "error_rate",
+                    "plot_type": "scatter",
+                    "position": [0, 1],
+                },
+                {
+                    "title": "Concurrency vs TTFT",
+                    "x_field": "num_concurrency",
+                    "y_field": "stats.ttft.mean",
+                    "plot_type": "line",
+                    "position": [1, 0],
+                },
+                {
+                    "title": "Throughput Distribution",
+                    "x_field": "num_concurrency",
+                    "y_field": "mean_total_tokens_throughput_tokens_per_s",
+                    "plot_type": "line",
+                    "position": [1, 1],
+                },
+            ],
+        },
+    }
+
+    @classmethod
+    def load_config(cls, config_source: Union[str, Dict, None] = None) -> PlotConfig:
+        """Load plot configuration from various sources."""
+        if config_source is None:
+            # Use default 2x4 preset
+            return cls.load_preset("2x4_default")
+
+        if isinstance(config_source, str):
+            if config_source in cls.PRESETS:
+                # Load preset
+                return cls.load_preset(config_source)
+            else:
+                # Load from file
+                return cls.load_from_file(config_source)
+
+        if isinstance(config_source, dict):
+            # Load from dictionary
+            return PlotConfig(**config_source)
+
+        raise ValueError(f"Invalid config source type: {type(config_source)}")
+
+    @classmethod
+    def load_preset(cls, preset_name: str) -> PlotConfig:
+        """Load a built-in preset configuration."""
+        if preset_name not in cls.PRESETS:
+            available = list(cls.PRESETS.keys())
+            raise ValueError(f"Unknown preset '{preset_name}'. Available: {available}")
+
+        return PlotConfig(**cls.PRESETS[preset_name])
+
+    @classmethod
+    def load_from_file(cls, file_path: str) -> PlotConfig:
+        """Load configuration from JSON file."""
+        path = Path(file_path)
+        if not path.exists():
+            raise FileNotFoundError(f"Plot config file not found: {file_path}")
+
+        try:
+            with open(path, "r") as f:
+                config_data = json.load(f)
+            return PlotConfig(**config_data)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON in config file {file_path}: {e}") from e
+        except Exception as e:
+            raise ValueError(f"Error loading config from {file_path}: {e}") from e
+
+    @classmethod
+    def save_config(cls, config: PlotConfig, file_path: str) -> None:
+        """Save configuration to JSON file."""
+        path = Path(file_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(path, "w") as f:
+            json.dump(config.model_dump(), f, indent=2)
+
+        logger.info(f"Plot configuration saved to {file_path}")
+
+    @classmethod
+    def get_available_fields(cls) -> Dict[str, str]:
+        """Get all available fields from AggregatedMetrics."""
+        fields = {}
+
+        # Direct fields
+        for field_name, field_info in AggregatedMetrics.model_fields.items():
+            if field_name != "stats":
+                fields[field_name] = field_info.description or field_name
+
+        # Stats fields with statistical measures
+        stats_measures = [
+            "min",
+            "max",
+            "mean",
+            "stddev",
+            "sum",
+            "p25",
+            "p50",
+            "p75",
+            "p90",
+            "p95",
+            "p99",
+        ]
+        stats_fields = [
+            "ttft",
+            "tpot",
+            "e2e_latency",
+            "output_latency",
+            "output_inference_speed",
+            "num_input_tokens",
+            "num_output_tokens",
+            "total_tokens",
+            "input_throughput",
+            "output_throughput",
+        ]
+
+        for field in stats_fields:
+            for measure in stats_measures:
+                field_path = f"stats.{field}.{measure}"
+                fields[field_path] = f"{field} {measure}"
+
+        return fields
+
+    @classmethod
+    def get_fields_from_data(
+        cls, metrics: AggregatedMetrics
+    ) -> Dict[str, Tuple[Any, str]]:
+        """
+        Extract available fields with actual values from real experiment data.
+
+        Returns:
+            Dict mapping field_path -> (value, type_name)
+        """
+        available_fields = {}
+
+        # Direct fields from AggregatedMetrics
+        for field_name in AggregatedMetrics.model_fields:
+            if field_name == "stats":
+                continue
+
+            try:
+                value = getattr(metrics, field_name)
+                if value is not None:
+                    field_type = type(value).__name__
+                    available_fields[field_name] = (value, field_type)
+            except AttributeError:
+                continue
+
+        # Stats fields - check which ones have actual data
+        if hasattr(metrics, "stats") and metrics.stats is not None:
+            stats = metrics.stats
+
+            # Get available stat fields from the stats object
+            for stat_field_name in stats.model_fields:
+                try:
+                    stat_field = getattr(stats, stat_field_name)
+                    if stat_field is not None:
+                        # Check each statistical measure
+                        for measure_name in stat_field.model_fields:
+                            try:
+                                measure_value = getattr(stat_field, measure_name)
+                                if measure_value is not None:
+                                    field_path = (
+                                        f"stats.{stat_field_name}.{measure_name}"
+                                    )
+                                    field_type = type(measure_value).__name__
+                                    available_fields[field_path] = (
+                                        measure_value,
+                                        field_type,
+                                    )
+                            except AttributeError:
+                                continue
+                except AttributeError:
+                    continue
+
+        return available_fields
+
+    @classmethod
+    def validate_field_path(
+        cls, field_path: str, sample_metrics: AggregatedMetrics
+    ) -> bool:
+        """Validate that a field path exists in AggregatedMetrics."""
+        try:
+            value = cls.get_field_value(sample_metrics, field_path)
+            return value is not None
+        except Exception:
+            return False
+
+    @classmethod
+    def get_field_value(cls, metrics: AggregatedMetrics, field_path: str) -> Any:
+        """Get value from metrics using field path (e.g., 'stats.ttft.mean')."""
+        parts = field_path.split(".")
+        value = metrics
+
+        for part in parts:
+            if hasattr(value, part):
+                value = getattr(value, part)
+            else:
+                raise AttributeError(f"Field path '{field_path}' not found")
+
+        return value

--- a/genai_bench/analysis/plot_report.py
+++ b/genai_bench/analysis/plot_report.py
@@ -80,7 +80,17 @@ def plot_graph(
     # Annotate
     for xx, yy, cc in zip(valid_x, valid_y, valid_concurrency, strict=False):
         annotation = f"{yy:.2f}" if x_label == "Concurrency" else f"{cc}"
-        ax.annotate(annotation, (xx, yy), fontsize=9)
+        ax.annotate(
+            annotation,
+            (xx, yy),
+            fontsize=9,
+            xytext=(4, 4),
+            textcoords="offset points",
+            ha="left",
+            bbox=dict(
+                boxstyle="round,pad=0.2", facecolor="white", alpha=0.8, edgecolor="none"
+            ),
+        )
 
     if y_label == "TTFT":
         ax.set_yscale("log", base=10)

--- a/genai_bench/cli/report.py
+++ b/genai_bench/cli/report.py
@@ -62,8 +62,7 @@ def excel(ctx, experiment_folder, excel_name, metric_percentile):
     type=str,
     required=True,
     prompt=True,
-    help="A dictionary containing filter criteria for the plot. Default: {}. "
-    "Example: '{'model': 'vllm-model'}'",
+    help="Key to group the data by (e.g., 'traffic_scenario', 'server_version').",
 )
 @click.option(
     "--filter-criteria",
@@ -73,16 +72,153 @@ def excel(ctx, experiment_folder, excel_name, metric_percentile):
     help="A dictionary containing filter criteria for the plot. Default: {}. "
     "Example: '{'model': 'vllm-model'}'",
 )
+@click.option(
+    "--plot-config",
+    type=click.Path(),
+    default=None,
+    help="Path to JSON plot configuration file. If not provided, uses default 2x4 "
+    "layout.",
+)
+@click.option(
+    "--preset",
+    type=click.Choice(["2x4_default", "simple_2x2"]),
+    default=None,
+    help="Use a built-in plot preset. Overrides --plot-config if both are provided.",
+)
+@click.option(
+    "--list-fields",
+    is_flag=True,
+    help="List all available fields with actual data from the experiment folder and "
+    "exit.",
+)
+@click.option(
+    "--validate-only",
+    is_flag=True,
+    help="Only validate the plot configuration without generating plots.",
+)
 @click.pass_context
-def plot(ctx, experiments_folder, filter_criteria, group_key):
+def plot(
+    ctx,
+    experiments_folder,
+    filter_criteria,
+    group_key,
+    plot_config,
+    preset,
+    list_fields,
+    validate_only,
+):
     """
     Plots the experiment(s) results based on filters and group.
+    Supports flexible plot configurations via JSON files or built-in presets.
     """
     LoggingManager("plot")
     logger = init_logger("genai_bench.plot")
+
+    # Handle --list-fields option
+    if list_fields:
+        from genai_bench.analysis.plot_config import PlotConfigManager
+
+        # Load experiment data to get real field availability
+        logger.info(f"Scanning experiment data in {experiments_folder}...")
+
+        if is_single_experiment_folder(experiments_folder):
+            experiment_metadata, run_data = load_one_experiment(
+                experiments_folder, filter_criteria
+            )
+            if not experiment_metadata or not run_data:
+                click.echo(f"❌ No experiment data found in {experiments_folder}")
+                return
+            run_data_list = [(experiment_metadata, run_data)]
+        else:
+            run_data_list = load_multiple_experiments(
+                experiments_folder, filter_criteria
+            )
+            if not run_data_list:
+                click.echo(
+                    "❌ No valid experiment data found for multiple experiments."
+                )
+                return
+
+        # Extract available fields from actual data
+        try:
+            _, experiment_metrics = run_data_list[0]
+            first_scenario = list(experiment_metrics.keys())[0]
+            first_concurrency = list(experiment_metrics[first_scenario].keys())[0]
+            sample_metrics = experiment_metrics[first_scenario][first_concurrency][
+                "aggregated_metrics"
+            ]
+
+            available_fields = PlotConfigManager.get_fields_from_data(sample_metrics)
+
+            click.echo(
+                f"Available fields from experiment data in {experiments_folder}:"
+            )
+            click.echo("=" * 70)
+            click.echo(
+                f"Found {len(available_fields)} available fields with actual data:"
+            )
+            click.echo()
+
+            # Group fields by category for better readability
+            direct_fields = []
+            stats_fields = []
+
+            for field_path, (value, field_type) in sorted(available_fields.items()):
+                if field_path.startswith("stats."):
+                    stats_fields.append((field_path, value, field_type))
+                else:
+                    direct_fields.append((field_path, value, field_type))
+
+            if direct_fields:
+                click.echo("📊 Direct Metrics:")
+                for field_path, value, field_type in direct_fields:
+                    click.echo(f"  {field_path:<35} = {value} ({field_type})")
+                click.echo()
+
+            if stats_fields:
+                click.echo("📈 Statistical Metrics:")
+                for field_path, value, field_type in stats_fields:
+                    click.echo(f"  {field_path:<35} = {value} ({field_type})")
+
+        except Exception as e:
+            click.echo(f"❌ Error extracting fields from experiment data: {e}")
+            # Fallback to static field list
+            click.echo("\nFalling back to static field definitions...")
+            fields = PlotConfigManager.get_available_fields()
+            click.echo("Available fields from AggregatedMetrics schema:")
+            click.echo("=" * 50)
+            for field_path, description in sorted(fields.items()):
+                click.echo(f"{field_path:<40} - {description}")
+
+        return
+
+    # Load plot configuration
+    try:
+        from genai_bench.analysis.flexible_plot_report import (
+            plot_experiment_data_flexible,
+            validate_plot_config_with_data,
+        )
+        from genai_bench.analysis.plot_config import PlotConfigManager
+
+        if preset:
+            config = PlotConfigManager.load_preset(preset)
+            logger.info(f"Using preset configuration: {preset}")
+        elif plot_config:
+            config = PlotConfigManager.load_from_file(plot_config)
+            logger.info(f"Using configuration from: {plot_config}")
+        else:
+            config = PlotConfigManager.load_preset("2x4_default")
+            logger.info("Using default 2x4 configuration")
+
+    except Exception as e:
+        logger.error(f"Error loading plot configuration: {e}")
+        return
+
+    # Load experiment data
     logger.info(
         f"Plotting experiments in {experiments_folder} with filter: {filter_criteria}"
     )
+
     if is_single_experiment_folder(experiments_folder):
         experiment_metadata, run_data = load_one_experiment(
             experiments_folder, filter_criteria
@@ -92,18 +228,45 @@ def plot(ctx, experiments_folder, filter_criteria, group_key):
                 f"No experiment_metadata or run_data found in {experiments_folder}"
             )
             return
+        run_data_list = [(experiment_metadata, run_data)]
+    else:
+        run_data_list = load_multiple_experiments(experiments_folder, filter_criteria)
+        if not run_data_list:
+            logger.info("No valid experiment data found for multiple experiments.")
+            return
+
+    # Validate configuration with actual data
+    validation_errors = validate_plot_config_with_data(config, run_data_list)
+    if validation_errors:
+        logger.error("Plot configuration validation failed:")
+        for error in validation_errors:
+            logger.error(f"  - {error}")
+        if validate_only:
+            return
+        logger.warning("Proceeding with plot generation despite validation errors...")
+    else:
+        logger.info("Plot configuration validation passed")
+        if validate_only:
+            logger.info(
+                "Configuration is valid. Use without --validate-only to generate plots."
+            )
+            return
+
+    # Generate plots using flexible system
+    try:
+        plot_experiment_data_flexible(
+            run_data_list=run_data_list,
+            group_key=group_key,
+            experiment_folder=experiments_folder,
+            plot_config=config,
+        )
+        logger.info("Plot generation completed successfully")
+    except Exception as e:
+        logger.error(f"Error generating plots: {e}")
+        # Fallback to originally plotting system
+        logger.info("Falling back to original plotting system...")
         plot_experiment_data(
-            [(experiment_metadata, run_data)],  # Single experiment is wrapped in a list
+            run_data_list,
             group_key=group_key,
             experiment_folder=experiments_folder,
         )
-    else:
-        run_data_list = load_multiple_experiments(experiments_folder, filter_criteria)
-        if run_data_list:
-            plot_experiment_data(
-                run_data_list,
-                group_key=group_key,
-                experiment_folder=experiments_folder,
-            )
-        else:
-            logger.info("No valid experiment data found for multiple experiments.")

--- a/genai_bench/cli/report.py
+++ b/genai_bench/cli/report.py
@@ -62,7 +62,8 @@ def excel(ctx, experiment_folder, excel_name, metric_percentile):
     type=str,
     required=True,
     prompt=True,
-    help="Key to group the data by (e.g., 'traffic_scenario', 'server_version').",
+    help="Key to group the data by (e.g., 'traffic_scenario', 'server_version'). "
+    "Use 'none' for single scenario analysis.",
 )
 @click.option(
     "--filter-criteria",
@@ -81,7 +82,9 @@ def excel(ctx, experiment_folder, excel_name, metric_percentile):
 )
 @click.option(
     "--preset",
-    type=click.Choice(["2x4_default", "simple_2x2"]),
+    type=click.Choice(
+        ["2x4_default", "simple_2x2", "multi_line_latency", "single_scenario_analysis"]
+    ),
     default=None,
     help="Use a built-in plot preset. Overrides --plot-config if both are provided.",
 )


### PR DESCRIPTION
Refactor plotting system to support custom plot configurations beyond the fixed 2x4 layout. Users can now define any grid layout and select any fields from AggregatedMetrics for plotting.

### New Features
- Flexible Plot Configuration (plot_config.py)
  - JSON-based configuration system for custom plot layouts
  - Support for any NxM grid layout (1x1 to 5x6)
  - Field path mapping from AggregatedMetrics (direct fields + stats.*.{measure})
  - Two built-in presets: "2x4_default" (original layout), "simple_2x2"

- Dynamic Plot Generation (flexible_plot_report.py)
  - FlexiblePlotGenerator class for configuration-driven plotting
  - Support for line, scatter, and bar plot types
  - Custom titles, labels, and positioning
  - Graceful error handling with fallback to original system
  - Automatic hiding of unused subplot positions

- Enhanced CLI (report.py)
  - `--plot-config <file.json>` for custom configurations
  - `--preset {2x4_default,simple_2x2}` for built-in layouts
  - `--list-fields` shows available fields from actual experiment data
  - `--validate-only` for configuration testing without plot generation
  - Real-time field validation against experiment data

- Example Configurations (examples/plot_configs/)
  - custom_2x2.json: Simple 2x2 performance overview
  - performance_focused.json: Comprehensive 2x3 analysis layout
  - README.md: Complete usage guide and field reference

### Key Benefits

- **Backwards Compatible**: Default behavior unchanged
  (uses 2x4_default preset)
- **Data-Driven**: --list-fields reads from actual experiment data, 
  not just schema
- **Flexible**: Users can plot any combination of 125+ available fields
- **Validated**: Configuration validation against real data prevents 
  runtime errors

 ### Breaking Changes
 None - all existing functionality preserved with same default behavior.

### Usage Examples

```bash
# List available fields from experiment data
genai-bench plot --experiments-folder /path/to/experiments \
  --group-key traffic_scenario --list-fields

# Use custom configuration
genai-bench plot --experiments-folder /path/to/experiments \
  --group-key traffic_scenario \
  --plot-config examples/plot_configs/custom_2x2.json

# Use built-in preset
genai-bench plot --experiments-folder /path/to/experiments \
  --group-key traffic_scenario --preset simple_2x2

# Validate configuration
genai-bench plot --plot-config my_config.json --validate-only
```