### PR TITLE
[BUG] Fix left tokens to sample in _sample_text

### DIFF
--- a/genai_bench/sampling/text.py
+++ b/genai_bench/sampling/text.py
@@ -10,6 +10,7 @@ from genai_bench.protocol import (
 )
 from genai_bench.sampling.base import Sampler
 from genai_bench.scenarios.base import EmbeddingDistribution, Scenario, TextDistribution
+from genai_bench.utils import calculate_char_token_ratio
 
 logger = init_logger(__name__)
 
@@ -38,6 +39,7 @@ class TextSampler(Sampler):
 
         self.data = data
         self.use_scenario = use_scenario
+        self.char_token_ratio = calculate_char_token_ratio(tokenizer, data)
 
         # Set ignore_eos based on scenario usage
         if use_scenario:
@@ -181,7 +183,7 @@ class TextSampler(Sampler):
                 if tokens > left_tokens_to_sample:
                     # This will cut off a line in the middle of a word, but
                     # that's ok since a llm should be able to handle that.
-                    prompt += line[:left_tokens_to_sample]
+                    prompt += line[:int(left_tokens_to_sample * self.char_token_ratio)]
                     return prompt
                 prompt += line
                 left_tokens_to_sample -= tokens

--- a/genai_bench/sampling/text.py
+++ b/genai_bench/sampling/text.py
@@ -183,7 +183,7 @@ class TextSampler(Sampler):
                 if tokens > left_tokens_to_sample:
                     # This will cut off a line in the middle of a word, but
                     # that's ok since a llm should be able to handle that.
-                    prompt += line[:int(left_tokens_to_sample * self.char_token_ratio)]
+                    prompt += line[: int(left_tokens_to_sample * self.char_token_ratio)]
                     return prompt
                 prompt += line
                 left_tokens_to_sample -= tokens

--- a/genai_bench/utils.py
+++ b/genai_bench/utils.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 from transformers import PreTrainedTokenizer
+from typing import List
 
 
 def sanitize_string(input_str: str):
@@ -34,14 +35,13 @@ def is_single_experiment_folder(folder_name: str) -> bool:
 
 def calculate_char_token_ratio(
     tokenizer: PreTrainedTokenizer,
-    data: str,
+    data: str | List[str],
     add_special_tokens: bool = False,
 ) -> float:
-    """
-    calculate the ratio of character to token using model tokenizer.
-    """
-    total_chars = len(data)
-    tokens = tokenizer.encode(data, add_special_tokens=add_special_tokens)
+    """Calculate the ratio of character to token using model tokenizer."""
+    content = data if isinstance(data, str) else " ".join(data)
+    total_chars = len(content)
+    tokens = tokenizer.encode(content, add_special_tokens=add_special_tokens)
     total_tokens = len(tokens)
 
     char_token_ratio = total_chars / total_tokens if total_tokens > 0 else 0

--- a/genai_bench/utils.py
+++ b/genai_bench/utils.py
@@ -47,6 +47,7 @@ def calculate_char_token_ratio(
     char_token_ratio = total_chars / total_tokens if total_tokens > 0 else 0
     return char_token_ratio
 
+
 def calculate_sonnet_char_token_ratio(tokenizer: PreTrainedTokenizer) -> float:
     """Calculate the ratio of character to token using model tokenizer."""
     sonnet_file = Path(__file__).parent.resolve() / "data/sonnet.txt"

--- a/genai_bench/utils.py
+++ b/genai_bench/utils.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 from transformers import PreTrainedTokenizer
+from typing import List
 
 
 def sanitize_string(input_str: str):
@@ -32,15 +33,25 @@ def is_single_experiment_folder(folder_name: str) -> bool:
     return len(subfolders) == 0
 
 
+def calculate_char_token_ratio(
+    tokenizer: PreTrainedTokenizer,
+    data: List[str],
+    add_special_tokens: bool = False,
+) -> float:
+    """
+    calculate the ratio of character to token using model tokenizer.
+    """
+    total_chars = len(data)
+    tokens = tokenizer.encode(data, add_special_tokens=add_special_tokens)
+    total_tokens = len(tokens)
+
+    char_token_ratio = total_chars / total_tokens if total_tokens > 0 else 0
+    return char_token_ratio
+
 def calculate_sonnet_char_token_ratio(tokenizer: PreTrainedTokenizer) -> float:
     """Calculate the ratio of character to token using model tokenizer."""
     sonnet_file = Path(__file__).parent.resolve() / "data/sonnet.txt"
     with open(sonnet_file, "r") as f:
         content = f.read()
 
-    total_chars = len(content)
-    tokens = tokenizer.encode(content, add_special_tokens=False)
-    total_tokens = len(tokens)
-
-    char_token_ratio = total_chars / total_tokens if total_tokens > 0 else 0
-    return char_token_ratio
+    return calculate_char_token_ratio(tokenizer, content, add_special_tokens=False)

--- a/genai_bench/utils.py
+++ b/genai_bench/utils.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 
 from transformers import PreTrainedTokenizer
-from typing import List
 
 
 def sanitize_string(input_str: str):
@@ -35,7 +34,7 @@ def is_single_experiment_folder(folder_name: str) -> bool:
 
 def calculate_char_token_ratio(
     tokenizer: PreTrainedTokenizer,
-    data: List[str],
+    data: str,
     add_special_tokens: bool = False,
 ) -> float:
     """

--- a/tests/sampling/test_base.py
+++ b/tests/sampling/test_base.py
@@ -23,9 +23,13 @@ def mock_vision_dataset():
 def test_sampler_factory(mock_vision_dataset):
     text_data = ["Sample text 1", "Sample text 2"]
 
+    # Create a tokenizer mock that returns a list of token ids so len() works
+    tokenizer = Mock()
+    tokenizer.encode.return_value = [1, 2, 3]
+
     sampler = Sampler.create(
         task="text-to-text",
-        tokenizer=Mock(),
+        tokenizer=tokenizer,
         model="gpt-3",
         data=text_data,
         use_scenario=True,
@@ -34,7 +38,7 @@ def test_sampler_factory(mock_vision_dataset):
 
     sampler = Sampler.create(
         task="text-to-embeddings",
-        tokenizer=Mock(),
+        tokenizer=tokenizer,
         model="gpt-3",
         data=text_data,
         use_scenario=True,
@@ -43,7 +47,7 @@ def test_sampler_factory(mock_vision_dataset):
 
     sampler = Sampler.create(
         task="image-text-to-text",
-        tokenizer=Mock(),
+        tokenizer=tokenizer,
         model="gpt-3",
         data=mock_vision_dataset,
         use_scenario=False,
@@ -52,7 +56,7 @@ def test_sampler_factory(mock_vision_dataset):
 
     sampler = Sampler.create(
         task="image-to-embeddings",
-        tokenizer=Mock(),
+        tokenizer=tokenizer,
         model="gpt-3",
         data=mock_vision_dataset,
     )


### PR DESCRIPTION
Fix left tokens to sample in _sample_text

Motivation:
The line is divided if the number of tokens on it is greater than needed. Specifically, from the sample_text function:
                if tokens > left_tokens_to_sample:
                    # This will cut off a line in the middle of a word, but
                    # that's ok since a llm should be able to handle that.
                    prompt += line[:left_tokens_to_sample]
This part essentially assumes that each token is a character, even though this isn't true. 

Changes:
Abstract a function to calculate the char_token_ratio and then multiply it by the left tokens to sample to get prompt from line. 