### PR TITLE
[ci] Fix GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,10 +9,16 @@ on:
       - main
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
 jobs:
-  docs:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,6 +38,22 @@ jobs:
       - name: Build documentation
         run: mkdocs build --config-file docs/.config/mkdocs-gh-pages.yml
 
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
       - name: Deploy to GitHub Pages
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: mkdocs gh-deploy --config-file docs/.config/mkdocs-gh-pages.yml --force
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
 ## Fix GitHub Pages deployment workflow

  This PR fixes the GitHub Pages deployment that has been broken for 12+ hours, preventing documentation updates from being published.

  ### Problem
  - The workflow was using `mkdocs gh-deploy` which only pushes to the `gh-pages` branch
  - Since the repository is configured to use "GitHub Actions" as the deployment source in Settings > Pages, it requires the `actions/deploy-pages`
  action
  - This mismatch caused the gh-pages branch to update but no actual deployment to occur
  - The site remained stuck on a 12-hour-old deployment despite multiple merged changes

  ### Solution
  1. **Updated the workflow to use the official GitHub Pages deployment actions:**
     - Split into `build` and `deploy` jobs
     - Added proper permissions (`pages: write`, `id-token: write`)
     - Added concurrency control to prevent overlapping deployments
     - Use `actions/configure-pages`, `actions/upload-pages-artifact`, and `actions/deploy-pages`

  2. **Fixed the MkDocs configuration:**
     - Replaced the broken `INHERIT` directive with full Material theme configuration
     - Fixed `docs_dir` and `site_dir` paths to work correctly from repository root
     - Updated `site_url` to `https://docs.sglang.ai/genai-bench`

  ### Result
  - GitHub Pages deployments will now trigger automatically on merge to main
  - The Material theme will be properly applied
  - Documentation updates will be reflected immediately after merge

addresses #18 