### PR TITLE
fix(cli): fix typo in the help message of `--traffic-scenario`

### DIFF
--- a/genai_bench/cli/option_groups.py
+++ b/genai_bench/cli/option_groups.py
@@ -446,7 +446,7 @@ def experiment_options(func):
                    - Format: E(max_tokens_per_document)
                    - Examples: E(1024)
 
-                Supported scenarios for  are:
+                Supported scenarios are:
 
                 \b
                 1.  **ReRank (R)**: Documents and query is input.


### PR DESCRIPTION
Fix typo in the help message of `--traffic-scenario`.

`Supported scenarios for  are:` => `Supported scenarios are:`