### PR TITLE
docs: remove non-existent entry of plot examples in mkdocs

### DIFF
--- a/docs/.config/mkdocs-gh-pages.yml
+++ b/docs/.config/mkdocs-gh-pages.yml
@@ -129,7 +129,6 @@ nav:
     - Upload Results: user-guide/upload-benchmark-result.md
   - Examples:
     - examples/index.md
-    - Plot Configuration: examples/plot-config-examples.md
   - Development:
     - development/index.md
     - Contributing: development/contributing.md


### PR DESCRIPTION
This pull request removes a non-existent entry of plot examples `examples/plot-config-examples.md` in mkdocs.