### PR TITLE
[Bug Fix] OCIModelAuthAdapter.get_credentials() returning wrong object type

### DIFF
--- a/genai_bench/auth/oci/model_auth_adapter.py
+++ b/genai_bench/auth/oci/model_auth_adapter.py
@@ -67,4 +67,4 @@ class OCIModelAuthAdapter(ModelAuthProvider):
         Returns:
             The OCI auth provider instance
         """
-        return self.oci_auth
+        return self.oci_auth.get_credentials()

--- a/genai_bench/auth/oci/model_auth_adapter.py
+++ b/genai_bench/auth/oci/model_auth_adapter.py
@@ -62,9 +62,11 @@ class OCIModelAuthAdapter(ModelAuthProvider):
             return "oci_unknown"
 
     def get_credentials(self) -> Any:
-        """Get the underlying OCI auth provider.
+        """Get the credentials of the underlying OCI auth provider.
+
+        This is used to authenticate with the OCI model service.
 
         Returns:
-            The OCI auth provider instance
+            The credentials of the underlying OCI auth provider
         """
         return self.oci_auth.get_credentials()

--- a/tests/auth/oci/test_model_auth_adapter.py
+++ b/tests/auth/oci/test_model_auth_adapter.py
@@ -55,7 +55,7 @@ class TestOCIModelAuthAdapter:
         adapter = OCIModelAuthAdapter(mock_oci_auth)
 
         credentials = adapter.get_credentials()
-        assert credentials is mock_oci_auth
+        assert credentials is mock_oci_auth.get_credentials()
 
     @pytest.mark.parametrize(
         "class_name,expected_auth_type",
@@ -109,7 +109,7 @@ class TestOCIModelAuthAdapter:
         assert "auth_type" in config
         assert "region" in config
         assert "oci_auth" not in config  # Should not include non-serializable object
-        assert adapter.get_credentials() is mock_oci_auth
+        assert adapter.get_credentials() is mock_oci_auth.get_credentials()
         assert adapter.get_auth_type().startswith("oci_")
 
     def test_error_handling(self):
@@ -140,5 +140,5 @@ class TestOCIModelAuthAdapter:
 
         assert adapter1.get_auth_type() == "oci_user_principal"
         assert adapter2.get_auth_type() == "oci_instance_principal"
-        assert adapter1.get_credentials() is mock_oci_auth1
-        assert adapter2.get_credentials() is mock_oci_auth2
+        assert adapter1.get_credentials() is mock_oci_auth1.get_credentials()
+        assert adapter2.get_credentials() is mock_oci_auth2.get_credentials()


### PR DESCRIPTION
## Issue
OCIModelAuthAdapter.get_credentials() should return signer instead of auth object. It's causing the GenerativeAiInferenceClient initialization failure.

##  What changes
1. Fixed get_credentials() method
2. Fixed unit test