### PR TITLE
[Bugfix] Fix token-based truncation and document duplication in TextSampler

### DIFF
--- a/tests/sampling/test_text.py
+++ b/tests/sampling/test_text.py
@@ -61,6 +61,7 @@ class TestTextSampler(unittest.TestCase):
 
     def test_sample_chat_request(self):
         self.tokenizer.encode.return_value = [1, 2, 3, 4, 5]
+        self.tokenizer.decode.return_value = "Test prompt text"
         scenario = NormalDistribution(
             mean_input_tokens=10,
             stddev_input_tokens=2,
@@ -103,6 +104,7 @@ class TestTextSampler(unittest.TestCase):
 
     def test_sample_embedding_request(self):
         self.tokenizer.encode.return_value = [1, 2, 3, 4, 5]
+        self.tokenizer.decode.return_value = "Test document text"
         embedding_sampler = TextSampler(
             tokenizer=self.tokenizer,
             model=self.model,
@@ -120,6 +122,7 @@ class TestTextSampler(unittest.TestCase):
 
     def test_sample_rerank_request(self):
         self.tokenizer.encode.return_value = [1, 2, 3, 4, 5]
+        self.tokenizer.decode.return_value = "Test text"
         rerank_sampler = TextSampler(
             tokenizer=self.tokenizer,
             model=self.model,


### PR DESCRIPTION
## Motivation

This PR addresses two issues in the TextSampler class:

  1. Token-based truncation (fixes #30)

  Previously, the _sample_text method was truncating lines by character count `(line[:left_tokens_to_sample])`, which could led to significant discrepancies when lines contained many tokens. This was particularly problematic for datasets with long lines or non-standard tokenization patterns.

  Fix: Now we properly encode each line to tokens and truncate at the exact token boundary:
  - Use `tokenizer.encode(line)` to get the actual token representation
  - Truncate the token list to the exact number needed
  - Decode only the truncated tokens back to text

  This ensures the returned prompt contains exactly the requested number of tokens, not an approximation based on character positions.

  2. Unique document sampling for embedding/rerank requests

  Previously, embedding and rerank requests were creating duplicate documents `(documents = [document] * self.batch_size)`, which doesn't properly evaluate model performance as all documents in a batch were identical.

  Fix: Each document in the batch is now independently sampled:
  `documents = [self._sample_text(tokens_per_document) for _ in range(self.batch_size)]`

  This provides more realistic benchmarking by ensuring diversity in the batch.

  3. `ignore_eos` is not needed for non-text scenario. I noticed in server side logs that this param is sent during embedding.

## Modifications

  - _sample_text: Refactored to use token-level truncation instead of character-based truncation
  - _sample_embedding_request: Generate unique documents for each batch item
  - _sample_rerank_request: Generate unique documents for each batch item, fixed prefill token calculation