### PR TITLE
feat: Add flexible image dataset support and make scenarios optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ install: ## Install project dependencies.
 
 .PHONY: dev
 dev: ## Install development dependencies.
-	uv pip install ".[dev]"
+	uv pip install ".[dev,multi-cloud]"
 
 .PHONY: test
 test: ## Run tests.

--- a/genai_bench/cli/option_groups.py
+++ b/genai_bench/cli/option_groups.py
@@ -297,14 +297,16 @@ def sampling_options(func):
     func = click.option(
         "--dataset-image-column",
         type=str,
-        default="image",
+        default=None,
         help="Column name containing images (for multimodal datasets).",
     )(func)
     func = click.option(
         "--dataset-prompt-column",
         type=str,
-        default="prompt",
-        help="Column name containing prompts (for CSV/HuggingFace datasets).",
+        default=None,
+        help="Column name containing prompts (for CSV/HuggingFace datasets). "
+        "If not specified, empty prompts will be used. "
+        "If specified, it will override the prompt column in the dataset config file.",
     )(func)
     func = click.option(
         "--dataset-path",

--- a/genai_bench/cli/option_groups.py
+++ b/genai_bench/cli/option_groups.py
@@ -305,8 +305,8 @@ def sampling_options(func):
         type=str,
         default=None,
         help="Column name containing prompts (for CSV/HuggingFace datasets). "
-        "If not specified, empty prompts will be used. "
-        "If specified, it will override the prompt column in the dataset config file.",
+        "If not specified, empty prompts will be used. For advanced usage, please"
+        "check out DatasetConfig.",
     )(func)
     func = click.option(
         "--dataset-path",

--- a/genai_bench/cli/validation.py
+++ b/genai_bench/cli/validation.py
@@ -42,12 +42,6 @@ DEFAULT_SCENARIOS_FOR_CHAT = [
     "D(7800,200)",
 ]
 
-DEFAULT_SCENARIOS_FOR_VISION = [
-    "I(512,512)",
-    "I(1024,512)",
-    "I(2048,2048)",
-]
-
 DEFAULT_SCENARIOS_FOR_EMBEDDING = [
     "E(64)",
     "E(128)",
@@ -69,9 +63,7 @@ DEFAULT_SCENARIOS_FOR_RERANK = [
 DEFAULT_SCENARIOS_BY_TASK = {
     "text-to-text": DEFAULT_SCENARIOS_FOR_CHAT,
     "text-to-rerank": DEFAULT_SCENARIOS_FOR_RERANK,
-    "image-text-to-text": DEFAULT_SCENARIOS_FOR_VISION,
     "text-to-embeddings": DEFAULT_SCENARIOS_FOR_EMBEDDING,
-    "image-to-embeddings": DEFAULT_SCENARIOS_FOR_VISION,
     # add other tasks and default scenarios as needed
 }
 

--- a/genai_bench/data/config.py
+++ b/genai_bench/data/config.py
@@ -54,8 +54,17 @@ class DatasetConfig(BaseModel):
     """Complete dataset configuration."""
 
     source: DatasetSourceConfig
-    prompt_column: str = Field("prompt", description="Column name containing prompts")
-    image_column: str = Field("image", description="Column name containing images")
+    prompt_column: Optional[str] = Field(
+        None, description="Column name containing prompts"
+    )
+    image_column: Optional[str] = Field(
+        None, description="Column name containing images"
+    )
+    prompt_lambda: Optional[str] = Field(
+        None,
+        description="Lambda expression string, "
+        'e.g. \'lambda item: f"Question: {item["question"]}"\'',
+    )
 
     @classmethod
     def from_file(cls, config_path: str) -> "DatasetConfig":
@@ -68,8 +77,8 @@ class DatasetConfig(BaseModel):
     def from_cli_args(
         cls,
         dataset_path: Optional[str] = None,
-        prompt_column: str = "prompt",
-        image_column: str = "image",
+        prompt_column: Optional[str] = None,
+        image_column: Optional[str] = None,
         **kwargs,
     ) -> "DatasetConfig":
         """Create configuration from CLI arguments for backward compatibility."""
@@ -107,4 +116,5 @@ class DatasetConfig(BaseModel):
             source=source_config,
             prompt_column=prompt_column,
             image_column=image_column,
+            prompt_lambda=None,
         )

--- a/genai_bench/data/loaders/base.py
+++ b/genai_bench/data/loaders/base.py
@@ -59,7 +59,7 @@ class DatasetLoader(ABC):
                     f"{self.media_type} loader."
                 )
 
-    def load_request(self) -> Union[List[str], List[Tuple[str, Image]]]:
+    def load_request(self) -> Union[List[str], List[Tuple[str, Any]]]:
         """Load data from the dataset source."""
         data = self.dataset_source.load()
         return self._process_loaded_data(data)

--- a/genai_bench/data/loaders/base.py
+++ b/genai_bench/data/loaders/base.py
@@ -2,8 +2,6 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any, List, Set, Tuple, Union
 
-from PIL.Image import Image
-
 from genai_bench.data.config import DatasetConfig
 from genai_bench.data.sources import DatasetSourceFactory
 from genai_bench.logging import init_logger
@@ -67,7 +65,7 @@ class DatasetLoader(ABC):
     @abstractmethod
     def _process_loaded_data(
         self, data: Any
-    ) -> Union[List[str], List[Tuple[str, Image]]]:
+    ) -> Union[List[str], List[Tuple[str, Any]]]:
         """
         Process data loaded from dataset source. Must be implemented by subclasses.
         """

--- a/genai_bench/data/loaders/factory.py
+++ b/genai_bench/data/loaders/factory.py
@@ -1,9 +1,7 @@
 """Factory for creating appropriate data loaders and loading data."""
 
 from pathlib import Path
-from typing import List, Tuple, Union, cast
-
-from PIL.Image import Image
+from typing import Any, List, Tuple, Union, cast
 
 from genai_bench.data.config import DatasetConfig, DatasetSourceConfig
 from genai_bench.data.loaders.image import ImageDatasetLoader
@@ -19,7 +17,7 @@ class DataLoaderFactory:
     @staticmethod
     def load_data_for_task(
         task: str, dataset_config: DatasetConfig
-    ) -> Tuple[Union[List[str], List[Tuple[str, Image]]], bool]:
+    ) -> Tuple[Union[List[str], List[Tuple[str, Any]]], bool]:
         """Load data for a specific task.
 
         Args:
@@ -34,7 +32,7 @@ class DataLoaderFactory:
         if input_modality == "text":
             return DataLoaderFactory._load_text_data(dataset_config, output_modality)
         elif "image" in input_modality:
-            return DataLoaderFactory._load_image_data(dataset_config), False
+            return DataLoaderFactory._load_image_data(dataset_config)
         else:
             raise ValueError(f"Unsupported input modality: {input_modality}")
 
@@ -78,9 +76,10 @@ class DataLoaderFactory:
         return text_data, use_scenario
 
     @staticmethod
-    def _load_image_data(dataset_config: DatasetConfig) -> List[Tuple[str, Image]]:
+    def _load_image_data(
+        dataset_config: DatasetConfig,
+    ) -> Tuple[List[Tuple[str, Any]], bool]:
         """Load image data."""
         loader = ImageDatasetLoader(dataset_config)
         data = loader.load_request()
-        # ImageDatasetLoader always returns List[Tuple[str, Image]]
-        return data  # type: ignore
+        return data, True  # type: ignore

--- a/genai_bench/sampling/image.py
+++ b/genai_bench/sampling/image.py
@@ -1,6 +1,6 @@
 import base64
 import random
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import PIL
 from PIL.Image import Image
@@ -35,27 +35,35 @@ class ImageSampler(Sampler):
         tokenizer,
         model: str,
         output_modality: str,
-        data: List[Tuple[str, Image]],
+        data: List[Tuple[str, Any]],
         additional_request_params: Optional[dict] = None,
         **kwargs,
     ):
         super().__init__(tokenizer, model, output_modality, additional_request_params)
         self.data = data
 
-    def sample(self, scenario: Scenario) -> UserRequest:
+    def sample(self, scenario: Optional[Scenario] = None) -> UserRequest:
         """
-        Samples a request based on the scenario.
+        Samples a request based on the scenario or dataset configuration.
 
         Args:
-            scenario (Scenario): The scenario to use for sampling.
+            scenario (Scenario, optional): The scenario to use for sampling.
+                If None, uses dataset configuration directly.
 
         Returns:
             UserRequest: A request object for the task.
         """
-        self._validate_scenario(scenario)
-
-        image_dimension, num_images, num_output_tokens = scenario.sample()
-        prompt, image_content = self._sample_image_and_text(image_dimension, num_images)
+        if scenario is not None:
+            self._validate_scenario(scenario)
+            image_dimension, num_images, num_output_tokens = scenario.sample()
+            prompt, image_content = self._sample_image_and_text(
+                image_dimension, num_images
+            )
+        else:
+            # Dataset-only mode
+            prompt, image_content = self._sample_image_and_text()
+            num_images = 1
+            num_output_tokens = None
 
         # TODO: create Delegated Request Creator to replace if-else
         if self.output_modality == "text":
@@ -72,14 +80,14 @@ class ImageSampler(Sampler):
         prompt: str,
         image_content: List[str],
         num_images: int,
-        num_output_tokens: int,
+        num_output_tokens: int | None,
     ) -> UserImageChatRequest:
         """
         Generates a `UserImageChatRequest` for image-text-to-text tasks.
 
         Args:
             prompt (str): The textual prompt accompanying the images.
-            image_content (List[str]): List of Base64-encoded images.
+            image_content (List[str]): List of image URLs (base64 data or http URLs).
             num_images (int): Number of images in the request.
             num_output_tokens (int): Number of output tokens expected.
 
@@ -103,7 +111,7 @@ class ImageSampler(Sampler):
         Generates a `UserImageEmbeddingRequest` for image-to-embedding tasks.
 
         Args:
-            image_content (List[str]): List of Base64-encoded images.
+            image_content (List[str]): List of image URLs (base64 data or http URLs).
             num_images (int): Number of images in the request.
 
         Returns:
@@ -119,53 +127,75 @@ class ImageSampler(Sampler):
             additional_request_params=self.additional_request_params,
         )
 
-    def _validate_scenario(self, scenario: Optional[Scenario]) -> None:
+    def _validate_scenario(self, scenario: Scenario) -> None:
         """
-        Validates that a scenario is provided and has the correct type.
+        Validates that a scenario has the correct type.
 
         Raises:
-            ValueError: If the scenario is invalid or missing.
+            ValueError: If the scenario is invalid.
         """
-        if scenario is None:
-            raise ValueError("A scenario is required for image sampling.")
         if not isinstance(scenario.scenario_type, MultiModality):
             raise ValueError(
                 f"Expected MultiModality for image tasks, got "
                 f"{type(scenario.scenario_type)}"
             )
 
-    def encode_image_base64(cls, image: Image) -> str:
-        """Convert image to base64 encoding format."""
-        buffered = BytesIO()
-        # TODO: why do we need this
-        if image.mode == "RGBA":
-            image = image.convert("RGB")  # convert to RGB before saving to JPEG
-        # Save the image in the buffer in JPEG format
-        image.save(buffered, format="JPEG")
-        encoded_string = base64.b64encode(buffered.getvalue()).decode("utf-8")
-        return encoded_string
-
     def _sample_image_and_text(
-        self, image_dimension: Tuple[int, int], num_images: int
+        self, image_dimension: Optional[Tuple[int, int]] = None, num_images: int = 1
     ) -> Tuple[str, List[str]]:
         """
         Loads and processes images and accompanying texts from the dataset.
 
         Args:
-            image_dimension (Tuple[int, int]): Dimensions to resize the images.
-            num_images (int): Number of images to load.
+            image_dimension (Tuple[int, int], optional): Dimensions to resize the
+                images.
+            num_images (int): Number of images to load. Defaults to 1.
 
         Returns:
             Tuple[str, List[str]]: A tuple containing:
                 - Texts concatenated as a single prompt.
-                - A list of Base64-encoded images.
+                - A list of image URLs (base64 data URLs or file:// URLs).
         """
         selected_data = random.choices(self.data, k=num_images)
         images, texts = [], []
 
         for data in selected_data:
-            image = data[1]
-            image = image.resize(image_dimension, PIL.Image.Resampling.LANCZOS)
-            images.append(self.encode_image_base64(image))
+            raw_image = data[1]
+            # Use process_image with resize parameter
+            processed_image = ImageSampler.process_image(
+                raw_image, resize=image_dimension
+            )
+            images.append(processed_image)
             texts.append(data[0])
         return " ".join(texts), images
+
+    @staticmethod
+    def process_image(image: Any, resize: tuple = None) -> str:
+        """
+        Process a single image input and return a multimedia content dictionary.
+
+        Supports three input types:
+        1. Dictionary with raw image bytes
+        2. PIL.Image.Image input
+        3. String input (URL or file path)
+        """
+        if isinstance(image, dict) and "bytes" in image:
+            image = PIL.Image.open(BytesIO(image["bytes"]))
+
+        if isinstance(image, Image):
+            if image.mode != "RGB":
+                image = image.convert("RGB")
+            if resize:
+                image = image.resize(resize, PIL.Image.Resampling.LANCZOS)
+            with BytesIO() as image_data:
+                image.save(image_data, format="JPEG")
+                image_base64 = base64.b64encode(image_data.getvalue()).decode("utf-8")
+            return f"data:image/jpeg;base64,{image_base64}"
+
+        if isinstance(image, str) and image.startswith(("http://", "https://")):
+            return image
+
+        raise ValueError(
+            f"Invalid image input {image}. Must be a PIL.Image.Image"
+            " or str or dictionary with raw image bytes."
+        )

--- a/genai_bench/sampling/image.py
+++ b/genai_bench/sampling/image.py
@@ -172,7 +172,7 @@ class ImageSampler(Sampler):
     @staticmethod
     def process_image(image: Any, resize: tuple = None) -> str:
         """
-        Process a single image input and return a multimedia content dictionary.
+        Process a single image input and return a data URL or HTTP(S) URL.
 
         Supports three input types:
         1. Dictionary with raw image bytes

--- a/genai_bench/user/aws_bedrock_user.py
+++ b/genai_bench/user/aws_bedrock_user.py
@@ -259,10 +259,22 @@ class AWSBedrockUser(BaseUser):
                     {"type": "text", "text": request.prompt}
                 ]
                 for image in request.image_content:
+                    # Handle different image formats for Bedrock
+                    if image.startswith("data:image/"):
+                        # Extract base64 data from data URL
+                        image_data = image.split(",", 1)[1]
+                    elif image.startswith(("http://", "https://")):
+                        # Bedrock doesn't support HTTP URLs - should be converted in
+                        # data loading phase
+                        raise ValueError(
+                            f"AWS Bedrock does not support HTTP URLs for images. "
+                            f"URL '{image}' should be processed during data loading."
+                        )
+
                     source_data: Dict[str, str] = {
                         "type": "base64",
                         "media_type": "image/jpeg",  # Assume JPEG
-                        "data": image,
+                        "data": image_data,
                     }
                     content.append({"type": "image", "source": source_data})
                 body["messages"].append({"role": "user", "content": content})

--- a/genai_bench/user/azure_openai_user.py
+++ b/genai_bench/user/azure_openai_user.py
@@ -396,10 +396,7 @@ class AzureOpenAIUser(BaseUser):
             # Multimodal request
             content: List[Dict[str, Any]] = [{"type": "text", "text": request.prompt}]
             for image in request.image_content:
-                image_url_data: Dict[str, str] = {
-                    "url": f"data:image/jpeg;base64,{image}"
-                }
-                content.append({"type": "image_url", "image_url": image_url_data})
+                content.append({"type": "image_url", "image_url": {"url": image}})
             messages.append({"role": "user", "content": content})
         else:
             # Text-only request

--- a/genai_bench/user/cohere_user.py
+++ b/genai_bench/user/cohere_user.py
@@ -324,10 +324,7 @@ class CohereUser(BaseUser):
                     f"scenario is requesting {num_sampled_images}"
                 )
             return {
-                "images": [
-                    f"data:image/jpeg;base64,{image}"
-                    for image in user_request.image_content
-                ],
+                "images": user_request.image_content,
                 "input_type": "IMAGE",
             }
         return {"texts": user_request.documents, "input_type": "CLUSTERING"}

--- a/genai_bench/user/gcp_vertex_user.py
+++ b/genai_bench/user/gcp_vertex_user.py
@@ -414,11 +414,28 @@ class GCPVertexUser(BaseUser):
                 # Multimodal request
                 parts: List[Dict[str, Any]] = [{"text": request.prompt}]
                 for image in request.image_content:
-                    inline_data: Dict[str, str] = {
-                        "mimeType": "image/jpeg",
-                        "data": image,
-                    }
-                    parts.append({"inlineData": inline_data})
+                    if image.startswith("data:image/"):
+                        # Extract base64 data from data URL for inline data
+                        image_data = image.split(",", 1)[1]
+                        parts.append(
+                            {
+                                "inlineData": {
+                                    "mimeType": "image/jpeg",
+                                    "data": image_data,
+                                }
+                            }
+                        )
+                    elif image.startswith(("http://", "https://", "gs://")):
+                        # Use fileData for HTTP URLs and Cloud Storage URIs
+                        parts.append(
+                            {
+                                "fileData": {
+                                    "mimeType": "image/jpeg",
+                                    "fileUri": image,
+                                }
+                            }
+                        )
+
                 contents.append({"parts": parts})
             else:
                 # Text-only request

--- a/genai_bench/user/gcp_vertex_user.py
+++ b/genai_bench/user/gcp_vertex_user.py
@@ -435,6 +435,10 @@ class GCPVertexUser(BaseUser):
                                 }
                             }
                         )
+                    else:
+                        raise ValueError(
+                            f"Unsupported image format for GCP Vertex AI: {type(image)}"
+                        )
 
                 contents.append({"parts": parts})
             else:

--- a/genai_bench/user/oci_cohere_user.py
+++ b/genai_bench/user/oci_cohere_user.py
@@ -268,10 +268,7 @@ class OCICohereUser(BaseUser):
                     f"image but, the value provided in traffic"
                     f"scenario is requesting {num_sampled_images}"
                 )
-            return [
-                f"data:image/jpeg;base64,{image}"
-                for image in user_request.image_content
-            ]
+            return user_request.image_content
         return user_request.documents
 
     def get_serving_mode(self, user_request: UserRequest) -> Any:

--- a/genai_bench/user/oci_genai_user.py
+++ b/genai_bench/user/oci_genai_user.py
@@ -8,8 +8,8 @@ from oci.generative_ai_inference import GenerativeAiInferenceClient
 from oci.generative_ai_inference.models import (
     ChatDetails,
     ChatResult,
-    GenericChatRequest,
     DedicatedServingMode,
+    GenericChatRequest,
     OnDemandServingMode,
 )
 

--- a/genai_bench/user/openai_user.py
+++ b/genai_bench/user/openai_user.py
@@ -63,7 +63,7 @@ class OpenAIUser(BaseUser):
             image_content = [
                 {
                     "type": "image_url",
-                    "image_url": {"url": f"data:image/jpeg;base64,{image}"},
+                    "image_url": {"url": image},
                 }
                 for image in user_request.image_content
             ]

--- a/tests/data/loaders/test_factory.py
+++ b/tests/data/loaders/test_factory.py
@@ -75,7 +75,7 @@ def test_load_data_for_image_task():
         )
 
         assert data == [("prompt1", "image1"), ("prompt2", "image2")]
-        assert use_scenario is False  # images don't use scenario-based sampling
+        assert use_scenario is True  # images use scenario-based sampling
 
 
 def test_load_data_for_invalid_task():

--- a/tests/data/loaders/test_image.py
+++ b/tests/data/loaders/test_image.py
@@ -110,7 +110,7 @@ def test_load_requests_override_prompt(mock_factory, mock_dataset, dataset_confi
     mock_source = MagicMock()
     mock_source.load.return_value = mock_dataset
     mock_factory.return_value = mock_source
-    dataset_config.prompt_lambda = 'lambda item: "Fixed prompt for all"'
+    dataset_config.prompt_lambda = 'lambda x: "Fixed prompt for all"'
 
     results = ImageDatasetLoader(dataset_config).load_request()
 

--- a/tests/data/loaders/test_image.py
+++ b/tests/data/loaders/test_image.py
@@ -8,13 +8,21 @@ from genai_bench.data.loaders.image import ImageDatasetLoader
 
 @pytest.fixture
 def mock_dataset():
+    # Create mock PIL Images instead of strings
+
+    from PIL import Image as PILImage
+
+    # Create fake image data
+    mock_image_1 = PILImage.new("RGB", (100, 100), color="red")
+    mock_image_2 = PILImage.new("RGB", (100, 100), color="blue")
+
     mock_dataset = MagicMock()
     mock_dataset.__len__.return_value = 2
     mock_dataset.features = ["image_column", "prompt_column"]
     mock_dataset.__iter__.return_value = iter(
         [
-            {"image_column": "image_data_1", "prompt_column": "prompt_1"},
-            {"image_column": "image_data_2", "prompt_column": "prompt_2"},
+            {"image_column": mock_image_1, "prompt_column": "prompt_1"},
+            {"image_column": mock_image_2, "prompt_column": "prompt_2"},
         ]
     )
     return mock_dataset
@@ -47,16 +55,28 @@ def test_load_requests_success(mock_factory, mock_dataset, dataset_config):
 
     results = ImageDatasetLoader(dataset_config).load_request()
 
-    expected_results = [("prompt_1", "image_data_1"), ("prompt_2", "image_data_2")]
-    assert results == expected_results
+    # Check we got 2 results with correct prompts and PIL Images
+    assert len(results) == 2
+    assert results[0][0] == "prompt_1"
+    assert results[1][0] == "prompt_2"
+    # Verify images are PIL Images
+    from PIL import Image as PILImage
+
+    assert isinstance(results[0][1], PILImage.Image)
+    assert isinstance(results[1][1], PILImage.Image)
 
 
 @patch("genai_bench.data.sources.DatasetSourceFactory.create")
 def test_load_requests_missing_prompt(mock_factory, mock_dataset, dataset_config):
     """Test if load_requests handles missing prompt column"""
+    from PIL import Image as PILImage
+
+    mock_image_1 = PILImage.new("RGB", (100, 100), color="red")
+    mock_image_2 = PILImage.new("RGB", (100, 100), color="blue")
+
     mock_dataset.__iter__.return_value = [
-        {"image_column": "image_data_1"},
-        {"image_column": "image_data_2"},
+        {"image_column": mock_image_1},
+        {"image_column": mock_image_2},
     ]
     mock_source = MagicMock()
     mock_source.load.return_value = mock_dataset
@@ -65,8 +85,12 @@ def test_load_requests_missing_prompt(mock_factory, mock_dataset, dataset_config
 
     results = ImageDatasetLoader(dataset_config).load_request()
 
-    expected_results = [("", "image_data_1"), ("", "image_data_2")]
-    assert results == expected_results
+    # Check results have empty prompts and PIL Images
+    assert len(results) == 2
+    assert results[0][0] == ""
+    assert results[1][0] == ""
+    assert isinstance(results[0][1], PILImage.Image)
+    assert isinstance(results[1][1], PILImage.Image)
 
 
 @patch("genai_bench.data.sources.DatasetSourceFactory.create")
@@ -78,3 +102,90 @@ def test_load_requests_empty_dataset(mock_factory, mock_empty_dataset, dataset_c
 
     results = ImageDatasetLoader(dataset_config).load_request()
     assert results == []
+
+
+@patch("genai_bench.data.sources.DatasetSourceFactory.create")
+def test_load_requests_override_prompt(mock_factory, mock_dataset, dataset_config):
+    """Test if load_requests uses prompt_lambda for fixed prompt"""
+    mock_source = MagicMock()
+    mock_source.load.return_value = mock_dataset
+    mock_factory.return_value = mock_source
+    dataset_config.prompt_lambda = 'lambda item: "Fixed prompt for all"'
+
+    results = ImageDatasetLoader(dataset_config).load_request()
+
+    # Check fixed prompt is used for all images
+    assert len(results) == 2
+    assert results[0][0] == "Fixed prompt for all"
+    assert results[1][0] == "Fixed prompt for all"
+    from PIL import Image as PILImage
+
+    assert isinstance(results[0][1], PILImage.Image)
+    assert isinstance(results[1][1], PILImage.Image)
+
+
+@patch("genai_bench.data.sources.DatasetSourceFactory.create")
+def test_load_requests_missing_prompt_column_in_data(mock_factory, dataset_config):
+    """Test if load_requests fails fast when prompt column doesn't exist in data"""
+    from PIL import Image as PILImage
+
+    mock_image_1 = PILImage.new("RGB", (100, 100), color="red")
+    mock_image_2 = PILImage.new("RGB", (100, 100), color="blue")
+
+    # Dataset items don't have the prompt column
+    mock_dataset = MagicMock()
+    mock_dataset.__iter__.return_value = iter(
+        [
+            {"image_column": mock_image_1, "other_column": "other_1"},
+            {"image_column": mock_image_2, "other_column": "other_2"},
+        ]
+    )
+    mock_source = MagicMock()
+    mock_source.load.return_value = mock_dataset
+    mock_factory.return_value = mock_source
+
+    # Config specifies a prompt column that doesn't exist
+    dataset_config.prompt_column = "nonexistent_column"
+
+    # Should raise ValueError for missing column (fail fast)
+    with pytest.raises(ValueError, match="Cannot extract image data from dataset"):
+        ImageDatasetLoader(dataset_config).load_request()
+
+
+@patch("genai_bench.data.sources.DatasetSourceFactory.create")
+@patch("requests.get")
+@patch("PIL.Image.open")
+def test_load_requests_url_images(
+    mock_pil_open, mock_requests_get, mock_factory, dataset_config
+):
+    """Test if load_requests handles URL images"""
+    # Mock dataset with URL strings
+    mock_dataset = MagicMock()
+    mock_dataset.__iter__.return_value = iter(
+        [
+            {
+                "image_column": "https://example.com/image1.jpg",
+                "prompt_column": "prompt_1",
+            },
+            {
+                "image_column": "https://example.com/image2.jpg",
+                "prompt_column": "prompt_2",
+            },
+        ]
+    )
+    mock_source = MagicMock()
+    mock_source.load.return_value = mock_dataset
+    mock_factory.return_value = mock_source
+
+    results = ImageDatasetLoader(dataset_config).load_request()
+
+    # URLs are now passed through directly, not fetched
+    assert len(results) == 2
+    assert results[0][0] == "prompt_1"
+    assert results[0][1] == "https://example.com/image1.jpg"
+    assert results[1][0] == "prompt_2"
+    assert results[1][1] == "https://example.com/image2.jpg"
+
+    # No requests should be made during loading
+    assert mock_requests_get.call_count == 0
+    assert mock_pil_open.call_count == 0

--- a/tests/data/test_config.py
+++ b/tests/data/test_config.py
@@ -58,8 +58,9 @@ def test_dataset_config_defaults():
         type="file", path="/path/to/file.txt", file_format="txt"
     )
     config = DatasetConfig(source=source_config)
-    assert config.prompt_column == "prompt"
-    assert config.image_column == "image"
+    assert config.prompt_column is None
+    assert config.image_column is None
+    assert config.prompt_lambda is None
 
 
 def test_invalid_dataset_source_type():

--- a/tests/sampling/test_image.py
+++ b/tests/sampling/test_image.py
@@ -87,8 +87,6 @@ def test_image_sampler_with_invalid_scenario(mock_tokenizer, mock_vision_dataset
     ):
         sampler.sample(mock_scenario)
 
-    with pytest.raises(
-        ValueError,
-        match="A scenario is required for image sampling",
-    ):
-        sampler.sample(None)
+    # None scenario is now supported (dataset-only mode)
+    request = sampler.sample(None)
+    assert request is not None

--- a/tests/user/test_aws_bedrock_user.py
+++ b/tests/user/test_aws_bedrock_user.py
@@ -183,7 +183,7 @@ class TestAWSBedrockUser:
             prompt="Describe this image",
             model="anthropic.claude-v2",
             max_tokens=100,
-            image_content=["base64_image_data"],
+            image_content=["data:image/jpeg;base64,base64_image_data"],
             num_images=1,
             num_prefill_tokens=10,
         )

--- a/tests/user/test_azure_openai_user.py
+++ b/tests/user/test_azure_openai_user.py
@@ -168,7 +168,7 @@ class TestAzureOpenAIUser:
             prompt="Describe this image",
             model="gpt-4-vision",
             max_tokens=100,
-            image_content=["base64_image_data"],
+            image_content=["data:image/jpeg;base64,base64_image_data"],
             num_images=1,
             num_prefill_tokens=10,
         )

--- a/tests/user/test_gcp_vertex_user.py
+++ b/tests/user/test_gcp_vertex_user.py
@@ -206,7 +206,7 @@ class TestGCPVertexUser:
             prompt="Describe this image",
             model="gemini-pro-vision",
             max_tokens=100,
-            image_content=["base64_image_data"],
+            image_content=["data:image/jpeg;base64,base64_image_data"],
             num_prefill_tokens=10,
             num_images=1,
         )

--- a/tests/user/test_oci_cohere_user.py
+++ b/tests/user/test_oci_cohere_user.py
@@ -319,7 +319,7 @@ def test_image_embeddings(mock_client_class, test_cohere_user):
     mock_client_instance.embed_text.return_value.status = 200
 
     test_cohere_user.on_start()
-    images = ["BASE64Image1"]
+    images = ["data:image/jpeg;base64,BASE64Image1"]
     model = "cohere-embed-v3"
     test_cohere_user.sample = lambda: UserImageEmbeddingRequest(
         documents=[],
@@ -340,7 +340,7 @@ def test_image_embeddings(mock_client_class, test_cohere_user):
 
     mock_client_instance.embed_text.assert_called_once_with(
         EmbedTextDetails(
-            inputs=[f"data:image/jpeg;base64,{images[0]}"],
+            inputs=images,
             input_type="IMAGE",
             compartment_id="compartmentId",
             serving_mode=OnDemandServingMode(model_id=model),

--- a/tests/user/test_oci_genai_user.py
+++ b/tests/user/test_oci_genai_user.py
@@ -3,15 +3,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 from oci.generative_ai_inference.models import (
     ChatDetails,
-    GenericChatRequest,
     DedicatedServingMode,
+    GenericChatRequest,
     OnDemandServingMode,
 )
 
-from genai_bench.protocol import (
-    UserChatRequest,
-    UserEmbeddingRequest,
-)
+from genai_bench.protocol import UserChatRequest, UserEmbeddingRequest
 from genai_bench.user.oci_genai_user import OCIGenAIUser
 
 

--- a/tests/user/test_openai_user.py
+++ b/tests/user/test_openai_user.py
@@ -120,7 +120,7 @@ def test_vision(mock_post, mock_openai_user):
         prompt="what's in the image?",
         num_prefill_tokens=5,
         image_content=[
-            "UklGRhowDgBXRUJQVlA4WAoAAAAgAAAA/wkAhAYASUNDUAwCAAAAAAIMbGNtcwIQAABtbnRyUkdCIFhZWiAH3AABABkAAwApADlhY3NwQVBQTAAAAAAA"
+            "data:image/jpeg;base64,UklGRhowDgBXRUJQVlA4WAoAAAAgAAAA/wkAhAYASUNDUAwCAAAAAAIMbGNtcwIQAABtbnRyUkdCIFhZWiAH3AABABkAAwApADlhY3NwQVBQTAAAAAAA"
         ],  # noqa:E501
         num_images=1,
         max_tokens=None,
@@ -506,7 +506,7 @@ def test_chat_vision_without_prefill_tokens(mock_post, mock_openai_user):
         model="gpt-4-vision",
         prompt="Describe this image",
         num_prefill_tokens=None,  # Vision request without prefill tokens
-        image_content=["base64_image_content"],
+        image_content=["data:image/jpeg;base64,base64_image_content"],
         num_images=1,
         additional_request_params={},
         max_tokens=10,


### PR DESCRIPTION
## Motivations

The current `ImageSampler` has the following issues:

1. Limited Prompt Extraction

It simply relies on `prompt_column` to extract prompt. However, most of the HuggingFace multimodal datasets don't have a string type of prompt available for straightforward extraction. For instance, [lmms-lab/LLaVA-OneVision-Data](https://huggingface.co/datasets/lmms-lab/LLaVA-OneVision-Data) stores prompts within nested conversation structures:

```
  {
    "conversations": [
      {"from": "human", "value": "What is shown in this image?"},
      {"from": "gpt", "value": "The image shows..."}
    ]
  }
```

This requires complex extraction logic that cannot be handled by a simple column reference.


2. Forced Image Resizing with Scenarios

- It tries to resize the image despite dataset characteristics. For specific datasets, users should be allowed to not pass any `ImageScenario`. Many modern vision models are trained on variable-resolution images and forcing resize through scenarios can:
  - Degrade image quality
  - Lose aspect ratio information
  - Add unnecessary overhead for datasets already at optimal resolution

3. Limited Image Data Type Support

- It only processes `Image` byte type data but doesn't support images with URLs. For a lot of large image datasets, providers only give image data as URLs instead of PIL.Image objects to:
  - Reduce dataset download size (URLs are just strings)
  - Enable lazy loading of images


## Modifications

- Remove `DEFAULT_SCENARIOS_FOR_VISION`
  - When benchmarking with a multimodal dataset, user should choose to explicitly set the scenario if they want resize their image inputs. Otherwise `ImageSampler` should simply pass the as-is image.

- Make prompt_column optional in DatasetConfig
  - Add prompt_lambda for flexible prompt generation via lambda expressions
  - Support empty prompts when no prompt source is specified
  - Enable dynamic prompt generation based on dataset item fields

- Implement process_image pattern for unified image handling
  - Support PIL Images, URLs (http/https), and base64 data URLs
  - Move image processing to sampling phase instead of loading phase
  - No URL fetching during data loading (pass URLs directly)

- Make scenarios optional for image datasets
  - Allow ImageSampler to work without scenarios (dataset-only mode)
  - Use sensible defaults when scenario is None (1 image, no output tokens limit)

- Update all user clients for new image format
  - OpenAI/Azure: Handle data URLs and raw base64
  - AWS Bedrock: Raise error for unsupported HTTP URLs
  - GCP Vertex: Support both inline data and file URIs
  - Cohere/OCI: Use URLs directly

- Fix all tests to match new implementation (791 tests passing)
  - Update `make dev` in Makefile