### PR TITLE
[Bugfix] Allow for benchmarking using large images.

### DIFF
--- a/genai_bench/data/config.py
+++ b/genai_bench/data/config.py
@@ -65,6 +65,10 @@ class DatasetConfig(BaseModel):
         description="Lambda expression string, "
         'e.g. \'lambda item: f"Question: {item["question"]}"\'',
     )
+    unsafe_allow_large_images: bool = Field(
+        False,
+        description="Overrides pillows internal DDOS protection",
+    )
 
     @classmethod
     def from_file(cls, config_path: str) -> "DatasetConfig":
@@ -117,4 +121,5 @@ class DatasetConfig(BaseModel):
             prompt_column=prompt_column,
             image_column=image_column,
             prompt_lambda=None,
+            unsafe_allow_large_images=False,
         )

--- a/genai_bench/data/loaders/base.py
+++ b/genai_bench/data/loaders/base.py
@@ -2,6 +2,8 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any, List, Set, Tuple, Union
 
+from PIL import Image as PILImage
+
 from genai_bench.data.config import DatasetConfig
 from genai_bench.data.sources import DatasetSourceFactory
 from genai_bench.logging import init_logger
@@ -32,6 +34,11 @@ class DatasetLoader(ABC):
         self._validate_source_format()
         self.dataset_source = DatasetSourceFactory.create(dataset_config.source)
 
+    def _disable_pillow_decompresion_check(self):
+        if self.dataset_config.unsafe_allow_large_images:
+            logger.info("Disabling pillows decompression bomb protection.")
+            PILImage.MAX_IMAGE_PIXELS = None
+
     def _validate_source_format(self):
         """Validate that the source format is supported by this loader."""
         source_type = self.dataset_config.source.type
@@ -59,6 +66,7 @@ class DatasetLoader(ABC):
 
     def load_request(self) -> Union[List[str], List[Tuple[str, Any]]]:
         """Load data from the dataset source."""
+        self._disable_pillow_decompresion_check()
         data = self.dataset_source.load()
         return self._process_loaded_data(data)
 


### PR DESCRIPTION
## Motivations
- When testing image benchmark with very large images, the pillow library throws an exception.
```
                             │ /home/vasheno/genai-bench/.venv/lib/python3.12/site-packages/PIL/Image.py:3449 in _decompression_bomb_check                     │               
                             │                                                                                                                                 │               
                             │   3446 │   │   │   f"Image size ({pixels} pixels) exceeds limit of {2 * MAX_IMAGE_PIXELS} "                                     │               
                             │   3447 │   │   │   "pixels, could be decompression bomb DOS attack."                                                            │               
                             │   3448 │   │   )                                                                                                                │               
                             │ ❱ 3449 │   │   raise DecompressionBombError(msg)                                                                                │               
                             │   3450 │                                                                                                                        │               
                             │   3451 │   if pixels > MAX_IMAGE_PIXELS:                                                                                        │               
                             │   3452 │   │   warnings.warn(                                                                                                   │               
                             ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯               
                             DecompressionBombError: Image size (179027968 pixels) exceeds limit of 178956970 pixels, could be decompression bomb DOS attack. 
```

## Modifications
- Adding a new CLI argument that gets passed to the ImageDataLoader which disables the pillow check (its responsbility)

## Testing

```
genai-bench benchmark \
  --api-backend openai \
--api-base "http://localhost:8000" \
--api-key "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" \
  --api-model-name "vllm-model" \
  --model-tokenizer "/mnt/data/models/Llama-3.2-11B-Vision-Instruct"  \
  --experiment-folder-name "content-moderation-benchmark"  \
  --task image-text-to-text \
  --max-time-per-run 15 \
  --max-requests-per-run 300 \
  --server-engine "vLLM" \
  --server-gpu-type "H100" \
  --server-version "latest" \
  --server-gpu-count 1 \
  --traffic-scenario "I(4096,4096)" --dataset-config datasetconfig.json
 
#datasetconfig.json

{
  "source": {
    "type": "huggingface",
    "path": "zhang0jhon/Aesthetic-4K",
    "huggingface_kwargs": {
      "split": "train"
    }
  },
  "prompt_column": "text",
  "image_column": "image",
  "unsafe_allow_large_images": true
}
```