### PR TITLE
Add spawn rate to prevent worker overload in distributed benchmarks

### DIFF
--- a/docs/user-guide/run-benchmark.md
+++ b/docs/user-guide/run-benchmark.md
@@ -202,12 +202,31 @@ To address this, you can increase the number of worker processes using the `--nu
 
 This distributes the load across multiple processes on a single machine, improving performance and ensuring your benchmark runs smoothly.
 
+### Controlling User Spawn Rate
+
+When running high-concurrency benchmarks with large payloads (e.g., 20k+ tokens), workers may become overwhelmed if all users are spawned immediately. This can cause worker heartbeat failures and restarts.
+
+To prevent this, use the `--spawn-rate` option to control how quickly users are spawned:
+
+```shell
+    --num-concurrency 500 \
+    --num-workers 16 \
+    --spawn-rate 50
+```
+
+**Examples:**
+- `--spawn-rate 50`: Spawn 50 users per second (takes 10 seconds to reach 500 users)
+- `--spawn-rate 100`: Spawn 100 users per second (takes 5 seconds to reach 500 users)
+- `--spawn-rate 500`: Spawn all users immediately (default behavior)
+
+
 ### Notes on Usage
 
 1. This feature is experimental, so monitor the system's behavior when enabling multiple workers.
 2. Recommended Limit: Do **not** set the number of workers to more than 16, as excessive worker processes can lead to resource contention and diminished performance.
 3. Ensure your system has sufficient CPU and memory resources to support the desired number of workers.
 4. Adjust the number of workers based on your target load and system capacity to achieve optimal results.
+5. For high-concurrency tests with large payloads, use `--spawn-rate` to prevent worker overload.
 
 
 ## Using Dataset Configurations

--- a/genai_bench/cli/cli.py
+++ b/genai_bench/cli/cli.py
@@ -406,8 +406,13 @@ def benchmark(
                 dashboard.start_run(max_time_per_run, start_time, max_requests_per_run)
 
                 # Use custom spawn rate if provided, otherwise use concurrency
-                actual_spawn_rate = spawn_rate if spawn_rate is not None else concurrency
-                logger.info(f"Starting benchmark with concurrency={concurrency}, spawn_rate={actual_spawn_rate}")
+                actual_spawn_rate = (
+                    spawn_rate if spawn_rate is not None else concurrency
+                )
+                logger.info(
+                    f"Starting benchmark with concurrency={concurrency}, "
+                    f"spawn_rate={actual_spawn_rate}"
+                )
                 environment.runner.start(concurrency, spawn_rate=actual_spawn_rate)
 
                 total_run_time = manage_run_time(

--- a/genai_bench/cli/cli.py
+++ b/genai_bench/cli/cli.py
@@ -117,6 +117,7 @@ def benchmark(
     dataset_image_column,
     num_workers,
     master_port,
+    spawn_rate,
     upload_results,
     namespace,
     # Storage auth options
@@ -404,7 +405,10 @@ def benchmark(
                 start_time = time.monotonic()
                 dashboard.start_run(max_time_per_run, start_time, max_requests_per_run)
 
-                environment.runner.start(concurrency, spawn_rate=concurrency)
+                # Use custom spawn rate if provided, otherwise use concurrency
+                actual_spawn_rate = spawn_rate if spawn_rate is not None else concurrency
+                logger.info(f"Starting benchmark with concurrency={concurrency}, spawn_rate={actual_spawn_rate}")
+                environment.runner.start(concurrency, spawn_rate=actual_spawn_rate)
 
                 total_run_time = manage_run_time(
                     max_time_per_run=max_time_per_run,

--- a/genai_bench/cli/option_groups.py
+++ b/genai_bench/cli/option_groups.py
@@ -574,6 +574,14 @@ def distributed_locust_options(func):
         help="Number of worker processes to spawn for the load test. "
         "By default it runs as a single process.",
     )(func)
+    func = click.option(
+        "--spawn-rate",
+        type=int,
+        default=None,
+        required=False,
+        help="Number of users to spawn per second. Defaults to concurrency value. "
+        "Use lower values (e.g., 10-50) for LLM workloads to prevent worker overload.",
+    )(func)
     return func
 
 

--- a/genai_bench/distributed/runner.py
+++ b/genai_bench/distributed/runner.py
@@ -158,7 +158,7 @@ class DistributedRunner:
         )
         # Create collector only for master in distributed mode
         self.metrics_collector = AggregatedMetricsCollector()
-        
+
         time.sleep(self.config.wait_time)
         self._register_message_handlers()
 
@@ -229,10 +229,12 @@ class DistributedRunner:
                 master_host=self.config.master_host, master_port=self.config.master_port
             )
             self._register_message_handlers()
-            
+
             # Add periodic health check logging
-            logger.info(f"Worker {worker_id} started successfully and connected to master")
-            
+            logger.info(
+                f"Worker {worker_id} started successfully and connected to master"
+            )
+
             runner.greenlet.join()
         except Exception as e:
             logger.error(f"Worker {worker_id} failed: {str(e)}")
@@ -327,7 +329,7 @@ class DistributedRunner:
                     logger.info(f"Terminating worker {i}")
                     process.terminate()
                     process.join(timeout=10)  # Wait up to 10 seconds
-                    
+
                     # Force kill if still alive
                     if process.is_alive():
                         logger.warning(f"Force killing worker {i}")

--- a/genai_bench/distributed/runner.py
+++ b/genai_bench/distributed/runner.py
@@ -158,6 +158,7 @@ class DistributedRunner:
         )
         # Create collector only for master in distributed mode
         self.metrics_collector = AggregatedMetricsCollector()
+        
         time.sleep(self.config.wait_time)
         self._register_message_handlers()
 
@@ -228,10 +229,15 @@ class DistributedRunner:
                 master_host=self.config.master_host, master_port=self.config.master_port
             )
             self._register_message_handlers()
+            
+            # Add periodic health check logging
+            logger.info(f"Worker {worker_id} started successfully and connected to master")
+            
             runner.greenlet.join()
         except Exception as e:
             logger.error(f"Worker {worker_id} failed: {str(e)}")
-            raise
+            # Don't raise here to prevent worker restart loops
+            return
 
     def _set_cpu_affinity(self, worker_id: int) -> None:
         """Set CPU affinity for worker process"""
@@ -314,9 +320,21 @@ class DistributedRunner:
             self.environment.runner.quit()
             self.environment.runner = None
 
-        for process in self._worker_processes:
-            process.terminate()
-            process.join()
+        # Gracefully terminate worker processes
+        for i, process in enumerate(self._worker_processes):
+            try:
+                if process.is_alive():
+                    logger.info(f"Terminating worker {i}")
+                    process.terminate()
+                    process.join(timeout=10)  # Wait up to 10 seconds
+                    
+                    # Force kill if still alive
+                    if process.is_alive():
+                        logger.warning(f"Force killing worker {i}")
+                        process.kill()
+                        process.join()
+            except Exception as e:
+                logger.error(f"Error terminating worker {i}: {e}")
 
     def _register_message_handlers(self) -> None:
         """Register message handlers based on runner type.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "locust>=2.32.4,<3.0.0",
+    "locust>=2.37.14,<3.0.0",
     "numpy>=1.26.4",
     "requests>=2.32.3,<3.0.0",
     "transformers>=4.44.2,<5.0.0",

--- a/tests/cli/test_cli_benchmark.py
+++ b/tests/cli/test_cli_benchmark.py
@@ -605,7 +605,9 @@ def test_benchmark_help_doesnt_prompt(cli_runner):
     "mock_http_requests",
     "mock_experiment_path",
 )
-def test_benchmark_command_with_spawn_rate(cli_runner, default_options, mock_report_and_plot):
+def test_benchmark_command_with_spawn_rate(
+    cli_runner, default_options, mock_report_and_plot
+):
     """Test benchmark command with spawn-rate option."""
     result = cli_runner.invoke(
         benchmark,
@@ -634,7 +636,9 @@ def test_benchmark_command_with_spawn_rate(cli_runner, default_options, mock_rep
     "mock_http_requests",
     "mock_experiment_path",
 )
-def test_benchmark_command_with_spawn_rate_and_workers(cli_runner, default_options, mock_runner_stats):
+def test_benchmark_command_with_spawn_rate_and_workers(
+    cli_runner, default_options, mock_runner_stats
+):
     """Test benchmark command with both spawn-rate and num-workers options."""
     with (
         patch("genai_bench.cli.cli.DistributedRunner") as mock_runner_class,
@@ -673,8 +677,10 @@ def test_benchmark_command_with_spawn_rate_and_workers(cli_runner, default_optio
     "mock_http_requests",
     "mock_experiment_path",
 )
-def test_spawn_rate_passed_to_runner_start(cli_runner, default_options, mock_runner_stats):
-    """Test that spawn-rate parameter is correctly passed to environment.runner.start."""
+def test_spawn_rate_passed_to_runner_start(
+    cli_runner, default_options, mock_runner_stats
+):
+    """Test that spawn-rate parameter is correctly passed to runner.start."""
     with (
         patch("genai_bench.cli.cli.DistributedRunner") as mock_runner_class,
         patch("genai_bench.cli.cli.Environment") as mock_env_class,
@@ -685,7 +691,7 @@ def test_spawn_rate_passed_to_runner_start(cli_runner, default_options, mock_run
         mock_runner_class.return_value = mock_runner
         mock_runner.environment = mock_env
         mock_runner.environment.runner.stats = mock_runner_stats
-        
+
         # Mock the runner.start method to capture its arguments
         mock_runner.environment.runner.start = MagicMock()
 
@@ -700,7 +706,7 @@ def test_spawn_rate_passed_to_runner_start(cli_runner, default_options, mock_run
             ],
         )
         assert result.exit_code == 0, f"Command failed with output: {result.output}"
-        
+
         # Verify that runner.start was called with the correct spawn_rate
         mock_runner.environment.runner.start.assert_called_with(100, spawn_rate=25)
 

--- a/tests/distributed/test_runner.py
+++ b/tests/distributed/test_runner.py
@@ -237,7 +237,7 @@ def test_worker_process_failure(mock_environment, mock_dashboard):
     # The worker process should now catch the exception and return gracefully
     # instead of re-raising it
     result = runner._worker_process(0)
-    
+
     # Verify that the function returns None (graceful exit)
     assert result is None
 

--- a/tests/distributed/test_runner.py
+++ b/tests/distributed/test_runner.py
@@ -234,8 +234,12 @@ def test_worker_process_failure(mock_environment, mock_dashboard):
         "Worker failed"
     )
 
-    with pytest.raises(WorkerSetupError):
-        runner._worker_process(0)
+    # The worker process should now catch the exception and return gracefully
+    # instead of re-raising it
+    result = runner._worker_process(0)
+    
+    # Verify that the function returns None (graceful exit)
+    assert result is None
 
 
 @patch("gevent.spawn")


### PR DESCRIPTION
Add spawn-rate option to prevent worker overload in distributed benchmarks

- Add `--spawn-rate` CLI option to control user spawning rate (defaults to concurrency)
- Improve worker process error handling and cleanup

Resolves: Worker processes being killed and restarted due to
inability to respond to heartbeats when spawning 500+ users immediately.

When running high-concurrency benchmarks with large payloads (e.g., 20k+ tokens), workers may become overwhelmed if all users are spawned immediately. This can cause worker heartbeat failures and restarts.

To prevent this, we can use the --spawn-rate option to control how quickly users are spawned:
```
    --num-concurrency 500 \
    --num-workers 16 \
    --spawn-rate 50
```
Examples:
--spawn-rate 50: Spawn 50 users per second (takes 10 seconds to reach 500 users)
--spawn-rate 100: Spawn 100 users per second (takes 5 seconds to reach 500 users)
--spawn-rate 500: Spawn all users immediately (default behavior)