### PR TITLE
[Docs] Fix errors in docs

### DIFF
--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -203,9 +203,9 @@ class OpenAIUser(BaseUser):
 
 1. Add tests for the new task in the appropriate test files.
 2. Include tests for:
-   - Request creation in the sampler.
-   - Task validation in the `User` class.
-   - End-to-end workflow using the new task.
+    - Request creation in the sampler.
+    - Task validation in the `User` class.
+    - End-to-end workflow using the new task.
 
 ---
 

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -138,7 +138,7 @@ Documentation uses MkDocs Material:
 pip install mkdocs-material
 
 # Serve docs locally
-mkdocs serve
+mkdocs serve -f docs/.config/mkdocs.yml
 
 # Build docs
 mkdocs build

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -135,13 +135,13 @@ Documentation uses MkDocs Material:
 
 ```bash
 # Install docs dependencies
-pip install mkdocs-material
+make docs
 
 # Serve docs locally
-mkdocs serve -f docs/.config/mkdocs.yml
+make docs-serve
 
 # Build docs
-mkdocs build
+make docs-build
 ```
 
 ## Code Style

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -15,7 +15,7 @@ pip install genai-bench
 For a specific version:
 
 ```bash
-pip install genai-bench==0.1.75
+pip install genai-bench==0.0.1
 ```
 
 ### Method 2: Development Installation
@@ -23,12 +23,15 @@ pip install genai-bench==0.1.75
 For development or to use the latest features:
 
 1. Please make sure you have Python3.11 installed. You can check out online how to set it up.
-2. Use the virtual environment from uv
+2. Use the virtual environment from uv. You can install it with: 
+
+```shell
+make uv
+```
 
 Activate the virtual environment to ensure the dev environment is correctly set up:
 
 ```shell
-make uv
 source .venv/bin/activate
 ```
 
@@ -47,7 +50,7 @@ For containerized environments:
 Pull the latest docker image:
 
 ```shell
-docker pull ghcr.io/moirai-internal/genai-bench:v0.0.1
+docker pull ghcr.io/moirai-internal/genai-bench:v0.0.2
 ```
 
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -12,12 +12,6 @@ The simplest way to install GenAI Bench:
 pip install genai-bench
 ```
 
-For a specific version:
-
-```bash
-pip install genai-bench==0.0.1
-```
-
 ### Method 2: Development Installation
 
 For development or to use the latest features:

--- a/docs/getting-started/task-definition.md
+++ b/docs/getting-started/task-definition.md
@@ -35,10 +35,10 @@ When you specify a task, the appropriate sampler (`TextSampler` or `ImageSampler
     genai-bench benchmark --task text-to-text ...
     ```
 
-* For an **image-to-text** task (e.g., generating a response for an image and text interleave message):
+* For an **image-text-to-text** task (e.g., generating a response for an image and text interleave message):
 
     ```bash
-    genai-bench benchmark --task image-to-text ...
+    genai-bench benchmark --task image-text-to-text ...
     ```
 
 * For an **image-to-embeddings** task (e.g., generating embeddings for similarity search):

--- a/docs/user-guide/multi-cloud-auth-storage.md
+++ b/docs/user-guide/multi-cloud-auth-storage.md
@@ -533,7 +533,7 @@ genai-bench benchmark \
 
 ### Multi-Modal Tasks
 
-**Image-to-text with GCP Vertex AI:**
+**Image-text-to-text with GCP Vertex AI:**
 ```bash
 genai-bench benchmark \
   --api-backend gcp-vertex \

--- a/docs/user-guide/multi-cloud-auth-storage.md
+++ b/docs/user-guide/multi-cloud-auth-storage.md
@@ -37,6 +37,7 @@ This separation allows you to benchmark models from one provider while storing r
 OpenAI uses API key authentication.
 
 **Required parameters:**
+
 - `--api-backend openai`
 - `--api-key` or `--model-api-key`: Your OpenAI API key
 
@@ -64,12 +65,14 @@ genai-bench benchmark --api-backend openai ...
 OCI supports multiple authentication methods.
 
 **Authentication types:**
+
 - `user_principal`: Default, uses OCI config file
 - `instance_principal`: For compute instances
 - `security_token`: For delegation tokens
 - `instance_obo_user`: Instance principal with user delegation
 
 **Required parameters:**
+
 - `--api-backend oci-cohere` or `--api-backend cohere`
 - `--auth`: Authentication type (default: user_principal)
 
@@ -104,23 +107,27 @@ genai-bench benchmark \
 
 ### OCI GenAI
 
-OCI GenAI provides access to Pretrained Foundational Models([Available Models](https://docs.oracle.com/en-us/iaas/Content/generative-ai/pretrained-models.htm)) through Oracle Cloud Infrastructure's Generative AI service. It uses the same authentication methods as OCI Cohere.
+OCI GenAI provides access to Pretrained Foundational Models ([Available Models](https://docs.oracle.com/en-us/iaas/Content/generative-ai/pretrained-models.htm)) through Oracle Cloud Infrastructure's Generative AI service. It uses the same authentication methods as OCI Cohere.
 
 **Authentication types:**
+
 - `user_principal`: Default, uses OCI config file
 - `instance_principal`: For compute instances
 - `security_token`: For delegation tokens
 - `instance_obo_user`: Instance principal with user delegation
 
 **Required parameters:**
+
 - `--api-backend oci-genai`
 - `--auth`: Authentication type (default: user_principal)
 - `--additional-request-params`: Must include `compartmentId` and `servingType`
 
 **Supported tasks:**
+
 - `text-to-text`: Chat completion
 
 **Serving modes:**
+
 - `ON_DEMAND`: Uses model_id for on-demand inference
 - `DEDICATED`: Uses endpointId for dedicated endpoints
 
@@ -198,6 +205,7 @@ AWS Bedrock supports IAM credentials and profiles.
 3. **Environment variables**: AWS SDK default behavior
 
 **Required parameters:**
+
 - `--api-backend aws-bedrock`
 - `--aws-region`: AWS region for Bedrock
 
@@ -248,6 +256,7 @@ Azure OpenAI supports API key and Azure AD authentication.
 2. **Azure AD**: Azure Active Directory token
 
 **Required parameters:**
+
 - `--api-backend azure-openai`
 - `--azure-endpoint`: Your Azure OpenAI endpoint
 - `--azure-deployment`: Your deployment name
@@ -293,6 +302,7 @@ GCP Vertex AI supports service account and API key authentication.
 3. **Application Default Credentials**: GCP SDK default
 
 **Required parameters:**
+
 - `--api-backend gcp-vertex`
 - `--gcp-project-id`: Your GCP project ID
 - `--gcp-location`: GCP region (default: us-central1)
@@ -325,6 +335,7 @@ genai-bench benchmark --api-backend gcp-vertex ...
 vLLM and SGLang use OpenAI-compatible APIs with optional authentication.
 
 **Required parameters:**
+
 - `--api-backend sglang` or `--api-backend vllm`
 - `--api-base`: Your server endpoint
 - `--api-key` or `--model-api-key`: Optional API key if authentication is enabled
@@ -349,6 +360,7 @@ Storage authentication is configured separately from model authentication, allow
 ### Common Storage Parameters
 
 All storage providers share these common parameters:
+
 - `--upload-results`: Flag to enable result upload
 - `--storage-provider`: Storage provider type (oci, aws, azure, gcp, github)
 - `--storage-bucket`: Bucket/container name
@@ -456,6 +468,7 @@ genai-bench benchmark \
 GitHub storage uploads results as release artifacts.
 
 **Required parameters:**
+
 - `--github-token`: Personal access token with repo permissions
 - `--github-owner`: Repository owner (user or organization)
 - `--github-repo`: Repository name
@@ -554,6 +567,7 @@ genai-bench benchmark \
 genai-bench supports environment variables for sensitive credentials:
 
 ### Model Authentication
+
 - `MODEL_API_KEY`: API key for OpenAI, Azure OpenAI, or GCP
 - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`: AWS credentials
 - `AWS_PROFILE`, `AWS_DEFAULT_REGION`: AWS configuration
@@ -591,23 +605,23 @@ genai-bench supports environment variables for sensitive credentials:
 ### Important Notes
 
 1. **Task-specific behavior**:
-   - For `text-to-embeddings` and `text-to-rerank` tasks, the iteration type automatically switches to `batch_size`
-   - For other tasks, `num_concurrency` iteration is used
-   - This is handled automatically by the CLI
+    - For `text-to-embeddings` and `text-to-rerank` tasks, the iteration type automatically switches to `batch_size`
+    - For other tasks, `num_concurrency` iteration is used
+    - This is handled automatically by the CLI
 
 2. **OCI GenAI requirements**:
-   - Only supports `text-to-text` task (chat completion) for Grok models
-   - Requires `compartmentId` in `additional-request-params`
-   - Supports both `ON_DEMAND` and `DEDICATED` serving types
-   - For dedicated endpoints, `endpointId` is required
+    - Only supports `text-to-text` task (chat completion) for Grok models
+    - Requires `compartmentId` in `additional-request-params`
+    - Supports both `ON_DEMAND` and `DEDICATED` serving types
+    - For dedicated endpoints, `endpointId` is required
 
 3. **Image format requirements**:
-   - Image inputs are expected to be in JPEG format for multi-modal tasks
-   - Base64 encoding is handled automatically
+    - Image inputs are expected to be in JPEG format for multi-modal tasks
+    - Base64 encoding is handled automatically
 
 4. **Token counting**:
-   - Different providers may use different tokenization methods
-   - Token estimates for embeddings tasks may vary by provider
+    - Different providers may use different tokenization methods
+    - Token estimates for embeddings tasks may vary by provider
 
 ### Troubleshooting
 1. **Check credentials**: Verify authentication credentials are correct
@@ -640,6 +654,7 @@ genai-bench benchmark \
 ```
 
 The main changes are:
+
 - `--bucket` → `--storage-bucket`
 - `--prefix` → `--storage-prefix`
 - Add `--storage-provider oci` (though OCI is the default for backward compatibility)

--- a/docs/user-guide/multi-cloud-quick-reference.md
+++ b/docs/user-guide/multi-cloud-quick-reference.md
@@ -206,7 +206,7 @@ genai-bench benchmark \
 
 ## Multi-Modal Tasks
 
-### Image-to-Text Benchmarking
+### Image-text-to-Text Benchmarking
 ```bash
 genai-bench benchmark \
   --api-backend gcp-vertex \

--- a/docs/user-guide/run-benchmark-using-docker.md
+++ b/docs/user-guide/run-benchmark-using-docker.md
@@ -5,7 +5,7 @@
 Pull the latest docker image:
 
 ```shell
-docker pull ghcr.io/moirai-internal/genai-bench:v0.0.1
+docker pull ghcr.io/moirai-internal/genai-bench:v0.0.2
 ```
 
 ## Building from Source
@@ -84,7 +84,7 @@ docker run \
     --api-key your_api_key \
     --api-model-name /models/meta-llama/Llama-4-Scout-17B-16E-Instruct \
     --model-tokenizer /models/meta-llama/Llama-4-Scout-17B-16E-Instruct \
-    --task image-to-text \
+    --task image-text-to-text \
     --max-time-per-run 10 \
     --max-requests-per-run 100 \
     --server-engine "SGLang" \
@@ -133,7 +133,7 @@ docker run \
     --api-key your_api_key \
     --api-model-name /models/meta-llama/Llama-4-Scout-17B-16E-Instruct \
     --model-tokenizer /models/meta-llama/Llama-4-Scout-17B-16E-Instruct \
-    --task image-to-text \
+    --task image-text-to-text \
     --max-time-per-run 10 \
     --max-requests-per-run 100 \
     --server-engine "SGLang" \

--- a/docs/user-guide/run-benchmark.md
+++ b/docs/user-guide/run-benchmark.md
@@ -283,6 +283,7 @@ When using HuggingFace datasets, you should always check if you need a `split`, 
 Then use: `--dataset-config config.json`
 
 **Benefits of config files:**
+
 - Access to ALL HuggingFace `load_dataset` parameters
 - Reusable and version-controllable
 - Support for complex configurations

--- a/docs/user-guide/run-benchmark.md
+++ b/docs/user-guide/run-benchmark.md
@@ -61,6 +61,8 @@ genai-bench benchmark \
             --dataset-config ./examples/dataset_configs/config_llava-bench-in-the-wild.json
 ```
 
+For complex setups, we recommend use of [dataset configs](#using-dataset-configurations).
+
 ## Start an embedding benchmark
 
 Below is a sample command to trigger an embedding benchmark task. Note: when running an embedding benchmark, it is recommended to set `--num-concurrency` to 1.
@@ -280,7 +282,25 @@ When using HuggingFace datasets, you should always check if you need a `split`, 
 }
 ```
 
-Then use: `--dataset-config config.json`
+Then use: `--dataset-config config.json`.
+
+**Benchmarking with large images:**
+When benchmarking with very large images, the pillow library throws an exception. To get around this, use a config with the arguement "unsafe_allow_large_images", which disables the warning.
+
+```json
+{
+  "source": {
+    "type": "huggingface",
+    "path": "zhang0jhon/Aesthetic-4K",
+    "huggingface_kwargs": {
+      "split": "train"
+    }
+  },
+  "prompt_column": "text",
+  "image_column": "image",
+  "unsafe_allow_large_images": true
+}
+```
 
 **Benefits of config files:**
 

--- a/docs/user-guide/run-benchmark.md
+++ b/docs/user-guide/run-benchmark.md
@@ -284,7 +284,7 @@ To specify a dataset config, use: `--dataset-config config.json`.
 ```
 
 **Benchmarking with large images:**
-When benchmarking with very large images, the pillow library throws an exception. To get around this, use a config with the argument "unsafe_allow_large_images", which disables the warning.
+When benchmarking with very large images, the pillow library throws an exception. To get around this, use a config with the argument `unsafe_allow_large_images`, which disables the warning.
 
 ```json
 {
@@ -302,7 +302,7 @@ When benchmarking with very large images, the pillow library throws an exception
 ```
 
 **Using prompt lambdas (vision tasks only):**
-If you want to benchmark a specific portion of a vision dataset, you can use the "prompt_lambda" argument to select only the desired section. When using `prompt_lambda`, you don't need to specify `prompt_column` as the lambda function generates the prompts dynamically. Note that `prompt_lambda` is only available for vision/multimodal tasks.
+If you want to benchmark a specific portion of a vision dataset, you can use the `prompt_lambda` argument to select only the desired section. When using `prompt_lambda`, you don't need to specify `prompt_column` as the lambda function generates the prompts dynamically. Note that `prompt_lambda` is only available for vision/multimodal tasks.
 
 
 ```json
@@ -318,8 +318,7 @@ If you want to benchmark a specific portion of a vision dataset, you can use the
   "image_column": "image",
   "prompt_lambda": "lambda x: x['conversations'][0]['value'] if len(x['conversations']) > 1 else ''"
 }
-
-3. **Check the dataset page on HuggingFace Hub** to see what configuration parameters are required.
+```
 
 **Benefits of config files:**
 

--- a/docs/user-guide/run-benchmark.md
+++ b/docs/user-guide/run-benchmark.md
@@ -47,10 +47,10 @@ genai-bench benchmark \
             --api-base "http://localhost:8180" \
             --api-model-name "/models/Phi-3-vision-128k-instruct" \
             --model-tokenizer "/models/Phi-3-vision-128k-instruct" \
-            --task image-to-text \
+            --task image-text-to-text \
             --max-time-per-run 15 \
             --max-requests-per-run 300 \
-            --server-engine vLLM \
+            --server-engine "vLLM" \
             --server-gpu-type A100-80G \
             --server-version "v0.6.0" \
             --server-gpu-count 4 \

--- a/docs/user-guide/run-benchmark.md
+++ b/docs/user-guide/run-benchmark.md
@@ -285,7 +285,7 @@ To specify a dataset config, use: `--dataset-config config.json`.
 ```
 
 **Benchmarking with large images:**
-When benchmarking with very large images, the pillow library throws an exception. To get around this, use a config with the arguement "unsafe_allow_large_images", which disables the warning.
+When benchmarking with very large images, the pillow library throws an exception. To get around this, use a config with the argument "unsafe_allow_large_images", which disables the warning.
 
 ```json
 {

--- a/docs/user-guide/run-benchmark.md
+++ b/docs/user-guide/run-benchmark.md
@@ -245,8 +245,7 @@ To specify a dataset config, use: `--dataset-config config.json`.
     "path": "ccdv/govreport-summarization",
     "huggingface_kwargs": {
       "split": "train",
-      "revision": "main",
-      "streaming": true
+      "revision": "main"
     }
   },
   "prompt_column": "report"

--- a/docs/user-guide/run-benchmark.md
+++ b/docs/user-guide/run-benchmark.md
@@ -235,6 +235,8 @@ For advanced HuggingFace configurations, create a JSON config file:
 **Important Note for HuggingFace Datasets:**
 When using HuggingFace datasets, you should always check if you need a `split`, `subset` parameter to avoid errors. If you don't specify, HuggingFace's `load_dataset` may return a `DatasetDict` object instead of a `Dataset`, which will cause the benchmark to fail.
 
+To specify a dataset config, use: `--dataset-config config.json`.
+
 **config.json:**
 ```json
 {
@@ -281,8 +283,6 @@ When using HuggingFace datasets, you should always check if you need a `split`, 
   "image_column": "image"
 }
 ```
-
-Then use: `--dataset-config config.json`.
 
 **Benchmarking with large images:**
 When benchmarking with very large images, the pillow library throws an exception. To get around this, use a config with the arguement "unsafe_allow_large_images", which disables the warning.

--- a/docs/user-guide/run-benchmark.md
+++ b/docs/user-guide/run-benchmark.md
@@ -233,7 +233,7 @@ Genai-bench supports flexible dataset configurations through two approaches:
 For advanced HuggingFace configurations, create a JSON config file:
 
 **Important Note for HuggingFace Datasets:**
-When using HuggingFace datasets, you should always check if you need a `split`, `subset` parameter to avoid errors. If you don't specify, HuggingFace's `load_dataset` may return a `DatasetDict` object instead of a `Dataset`, which will cause the benchmark to fail.
+When using HuggingFace datasets, you should always check if you need a `split`, `subset`, or `name` parameter to avoid errors. If you don't specify, HuggingFace's `load_dataset` may return a `DatasetDict` object instead of a `Dataset`, which will cause the benchmark to fail. Some datasets require additional configuration parameters like `name` to specify which subset of the dataset to load.
 
 To specify a dataset config, use: `--dataset-config config.json`.
 
@@ -300,6 +300,26 @@ When benchmarking with very large images, the pillow library throws an exception
   "unsafe_allow_large_images": true
 }
 ```
+
+**Using prompt lambdas (vision tasks only):**
+If you want to benchmark a specific portion of a vision dataset, you can use the "prompt_lambda" argument to select only the desired section. When using `prompt_lambda`, you don't need to specify `prompt_column` as the lambda function generates the prompts dynamically. Note that `prompt_lambda` is only available for vision/multimodal tasks.
+
+
+```json
+{
+  "source": {
+    "type": "huggingface",
+    "path": "lmms-lab/LLaVA-OneVision-Data",
+    "huggingface_kwargs": {
+      "split": "train",
+      "name": "CLEVR-Math(MathV360K)"
+    }
+  },
+  "image_column": "image",
+  "prompt_lambda": "lambda x: x['conversations'][0]['value'] if len(x['conversations']) > 1 else ''"
+}
+
+3. **Check the dataset page on HuggingFace Hub** to see what configuration parameters are required.
 
 **Benefits of config files:**
 

--- a/docs/user-guide/run-benchmark.md
+++ b/docs/user-guide/run-benchmark.md
@@ -50,9 +50,9 @@ genai-bench benchmark \
             --task image-text-to-text \
             --max-time-per-run 15 \
             --max-requests-per-run 300 \
-            --server-engine "vLLM" \
+            --server-engine "SGLang" \
             --server-gpu-type A100-80G \
-            --server-version "v0.6.0" \
+            --server-version "v0.4.10" \
             --server-gpu-count 4 \
             --traffic-scenario "I(256,256)" \
             --traffic-scenario "I(1024,1024)" \

--- a/docs/user-guide/upload-benchmark-result.md
+++ b/docs/user-guide/upload-benchmark-result.md
@@ -4,6 +4,7 @@
 
 ## OCI Object Storage (Legacy)
 GenAI Bench supports uploading benchmark results directly to OCI Object Storage. This feature is useful for:
+
 - Storing benchmark results in a centralized location
 - Sharing results with team members
 - Maintaining a historical record of benchmarks
@@ -37,6 +38,7 @@ The default object prefix is empty, but you can specify a prefix using the `--st
 ## Multi-Cloud Storage Support
 
 GenAI Bench now supports multiple cloud storage providers:
+
 - **AWS S3**: Use `--storage-provider aws`
 - **Azure Blob Storage**: Use `--storage-provider azure`
 - **GCP Cloud Storage**: Use `--storage-provider gcp`

--- a/genai_bench/data/loaders/text.py
+++ b/genai_bench/data/loaders/text.py
@@ -9,6 +9,8 @@ logger = init_logger(__name__)
 class TextDatasetLoader(DatasetLoader):
     """
     This datasetLoader is responsible for loading prompts from a data source.
+
+    TODO: Add support for prompt lambdas similar to ImageDatasetLoader.
     """
 
     supported_formats: Set[DatasetFormat] = {


### PR DESCRIPTION
Fixed some outdated/incorrect information in the documentation.

Changes:
 - Update version on installation page
 - Swap old 'image-to-text' for 'image-text-to-text' in various places
 - Bump v0.0.1 to v0.0.2 for the docker container instructions
 - Fixed markdown in various places