### PR TITLE
bugfix: Fix TextSampler sampling logic

### DIFF
--- a/genai_bench/sampling/text.py
+++ b/genai_bench/sampling/text.py
@@ -81,7 +81,9 @@ class TextSampler(Sampler):
             prompt = self._sample_text(num_input_tokens)
             max_tokens = num_output_tokens
             num_prefill_tokens = self.get_token_length(prompt)
-            self._check_discrepancy(num_input_tokens, num_prefill_tokens, threshold=0.15, tolerance=20)
+            self._check_discrepancy(
+                num_input_tokens, num_prefill_tokens, threshold=0.15, tolerance=20
+            )
 
         return UserChatRequest(
             model=self.model,

--- a/genai_bench/sampling/text.py
+++ b/genai_bench/sampling/text.py
@@ -186,7 +186,7 @@ class TextSampler(Sampler):
                     truncated_text = self.tokenizer.decode(
                         line_tokens[:left_tokens_to_sample], skip_special_tokens=True
                     )
-                    prompt += " " + truncated_text
+                    prompt += (" " if prompt else "") + truncated_text
                     return prompt
                 prompt += line
                 left_tokens_to_sample -= num_line_tokens

--- a/genai_bench/sampling/text.py
+++ b/genai_bench/sampling/text.py
@@ -81,7 +81,7 @@ class TextSampler(Sampler):
             prompt = self._sample_text(num_input_tokens)
             max_tokens = num_output_tokens
             num_prefill_tokens = self.get_token_length(prompt)
-            self._check_discrepancy(num_input_tokens, num_prefill_tokens, 0.15, 20)
+            self._check_discrepancy(num_input_tokens, num_prefill_tokens, threshold=0.15, tolerance=20)
 
         return UserChatRequest(
             model=self.model,

--- a/genai_bench/sampling/text.py
+++ b/genai_bench/sampling/text.py
@@ -81,7 +81,7 @@ class TextSampler(Sampler):
             prompt = self._sample_text(num_input_tokens)
             max_tokens = num_output_tokens
             num_prefill_tokens = self.get_token_length(prompt)
-            self._check_discrepancy(num_input_tokens, num_prefill_tokens)
+            self._check_discrepancy(num_input_tokens, num_prefill_tokens, 0.15, 20)
 
         return UserChatRequest(
             model=self.model,
@@ -179,14 +179,14 @@ class TextSampler(Sampler):
         while left_tokens_to_sample > 0:
             random.shuffle(data_copy)
             for line in data_copy:
-                line_tokens = self.tokenizer.encode(line)
+                line_tokens = self.tokenizer.encode(line, add_special_tokens=False)
                 num_line_tokens = len(line_tokens)
                 if num_line_tokens > left_tokens_to_sample:
                     # Truncate at token level, decode only needed tokens
                     truncated_text = self.tokenizer.decode(
-                        line_tokens[:left_tokens_to_sample]
+                        line_tokens[:left_tokens_to_sample], skip_special_tokens=True
                     )
-                    prompt += truncated_text
+                    prompt += " " + truncated_text
                     return prompt
                 prompt += line
                 left_tokens_to_sample -= num_line_tokens

--- a/tests/sampling/test_text.py
+++ b/tests/sampling/test_text.py
@@ -199,7 +199,7 @@ class TestTextSampler(unittest.TestCase):
 
         # Set up consistent tokenization behavior
         # Each line in test_data has a predictable token count
-        def mock_encode(text):
+        def mock_encode(text, add_special_tokens=False):
             # Map our test lines to token counts
             token_map = {
                 "Test line 1": [0, 1, 2],  # 3 tokens
@@ -216,8 +216,8 @@ class TestTextSampler(unittest.TestCase):
 
         self.tokenizer.encode.side_effect = mock_encode
         # Decode returns a string with same number of words as tokens
-        self.tokenizer.decode.side_effect = lambda tokens: " ".join(
-            ["word"] * len(tokens)
+        self.tokenizer.decode.side_effect = (
+            lambda tokens, skip_special_tokens=True: " ".join(["word"] * len(tokens))
         )
 
         # Test requesting exact token counts
@@ -263,4 +263,6 @@ class TestTextSampler(unittest.TestCase):
         _ = self.sampler._sample_text(requested_tokens)
 
         # Verify decode was called with truncated tokens
-        self.tokenizer.decode.assert_called_with(line_tokens[:requested_tokens])
+        self.tokenizer.decode.assert_called_with(
+            line_tokens[:requested_tokens], skip_special_tokens=True
+        )


### PR DESCRIPTION
## Motivation

`tokenizer.encode(line)` in `_sample_text` did not specify `add_special_tokens=False` but `self.get_token_length` sets `add_special_tokens=False`. This causes great discrepancy. Hence, `_check_discrepancy` will alway log warning.

## Modification

- Sets `tokenizer.encode(line, add_special_tokens=False)`