### PR TITLE
[Bugfix] Use image-text-to-text instead of image-to-text

### DIFF
--- a/genai_bench/user/aws_bedrock_user.py
+++ b/genai_bench/user/aws_bedrock_user.py
@@ -28,7 +28,7 @@ class AWSBedrockUser(BaseUser):
     supported_tasks = {
         "text-to-text": "chat",
         "text-to-embeddings": "embeddings",
-        "image-to-text": "chat",  # Same method handles both text and image
+        "image-text-to-text": "chat",  # Same method handles both text and image
     }
 
     host: Optional[str] = None

--- a/genai_bench/user/azure_openai_user.py
+++ b/genai_bench/user/azure_openai_user.py
@@ -32,7 +32,7 @@ class AzureOpenAIUser(BaseUser):
     supported_tasks = {
         "text-to-text": "chat",
         "text-to-embeddings": "embeddings",
-        "image-to-text": "chat",  # Same method handles both text and image
+        "image-text-to-text": "chat",  # Same method handles both text and image
     }
 
     host: Optional[str] = None

--- a/genai_bench/user/gcp_vertex_user.py
+++ b/genai_bench/user/gcp_vertex_user.py
@@ -32,7 +32,7 @@ class GCPVertexUser(BaseUser):
     supported_tasks = {
         "text-to-text": "chat",
         "text-to-embeddings": "embeddings",
-        "image-to-text": "chat",  # Same method handles both text and image
+        "image-text-to-text": "chat",  # Same method handles both text and image
     }
 
     host: Optional[str] = None

--- a/tests/user/test_aws_bedrock_user.py
+++ b/tests/user/test_aws_bedrock_user.py
@@ -51,7 +51,7 @@ class TestAWSBedrockUser:
         assert AWSBedrockUser.supported_tasks == {
             "text-to-text": "chat",
             "text-to-embeddings": "embeddings",
-            "image-to-text": "chat",
+            "image-text-to-text": "chat",
         }
 
     def test_init(self):

--- a/tests/user/test_azure_openai_user.py
+++ b/tests/user/test_azure_openai_user.py
@@ -52,7 +52,7 @@ class TestAzureOpenAIUser:
         assert AzureOpenAIUser.supported_tasks == {
             "text-to-text": "chat",
             "text-to-embeddings": "embeddings",
-            "image-to-text": "chat",
+            "image-text-to-text": "chat",
         }
 
     def test_init(self):

--- a/tests/user/test_gcp_vertex_user.py
+++ b/tests/user/test_gcp_vertex_user.py
@@ -55,7 +55,7 @@ class TestGCPVertexUser:
         assert GCPVertexUser.supported_tasks == {
             "text-to-text": "chat",
             "text-to-embeddings": "embeddings",
-            "image-to-text": "chat",
+            "image-text-to-text": "chat",
         }
 
     def test_init(self):


### PR DESCRIPTION
Motivation:
Several of the user classes (AzureOpenAI, GCPVertex, AWSBedrock) had `image-to-text` as a supported task instead of `image-text-to-text`. 

Changes:
Replaced `image-to-text` with `image-text-to-text` in the relevant user classes and tests. 