### PR TITLE
[Misc] Improve Excel report handling when performance threshold is not met

### DIFF
--- a/genai_bench/analysis/excel_report.py
+++ b/genai_bench/analysis/excel_report.py
@@ -1,6 +1,6 @@
 import json
 from os import PathLike
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
 from openpyxl import Workbook
 from openpyxl.styles import Alignment, Font, numbers
@@ -114,6 +114,8 @@ def _create_summary_sheet_common(
     for scenario in merged_scenarios:
         summary_value = -1
         summary_total_chars_per_hour = 0.0
+        display_summary_value: Union[str, int]
+        display_total_chars_per_hour: Union[str, float]
 
         iteration_key = experiment_metadata.iteration_type
 
@@ -144,14 +146,13 @@ def _create_summary_sheet_common(
             logger.warning(
                 f"For scenario '{scenario}', couldn't find a concurrency that meets "
                 f"the minimum output inference speed requirement: {threshold} tokens/s."
-                f" Please add lower concurrency test cases (e.g., concurrency=1), or "
-                f"check if the model service is running properly."
+                f" Please add lower concurrency test cases."
             )
             display_summary_value = "N/A"
             display_total_chars_per_hour = "N/A"
         else:
-            display_summary_value = str(summary_value)
-            display_total_chars_per_hour = str(summary_total_chars_per_hour)
+            display_summary_value = summary_value
+            display_total_chars_per_hour = summary_total_chars_per_hour
         rows.append(
             [
                 gpu_type_value,

--- a/genai_bench/analysis/excel_report.py
+++ b/genai_bench/analysis/excel_report.py
@@ -112,7 +112,7 @@ def _create_summary_sheet_common(
     rows = []
 
     for scenario in merged_scenarios:
-        summary_value = -9999
+        summary_value = -1
         summary_total_chars_per_hour = 0.0
 
         iteration_key = experiment_metadata.iteration_type
@@ -128,7 +128,7 @@ def _create_summary_sheet_common(
             )
             if metric_value is not None and metric_value > threshold:
                 if (
-                    summary_value != -9999
+                    summary_value != -1
                     and getattr(metrics, iteration_key) > summary_value
                 ):
                     prev_metrics = run_data[scenario][summary_value][
@@ -140,12 +140,24 @@ def _create_summary_sheet_common(
                 summary_value = max(summary_value, getattr(metrics, iteration_key))
                 summary_total_chars_per_hour = metrics.mean_total_chars_per_hour
 
+        if summary_value == -1:
+            logger.warning(
+                f"For scenario '{scenario}', couldn't find a concurrency that meets "
+                f"the minimum output inference speed requirement: {threshold} tokens/s."
+                f" Please add lower concurrency test cases (e.g., concurrency=1), or "
+                f"check if the model service is running properly."
+            )
+            display_summary_value = "N/A"
+            display_total_chars_per_hour = "N/A"
+        else:
+            display_summary_value = str(summary_value)
+            display_total_chars_per_hour = str(summary_total_chars_per_hour)
         rows.append(
             [
                 gpu_type_value,
                 SCENARIO_MAP.get(scenario, scenario),
-                summary_value,
-                summary_total_chars_per_hour,
+                display_summary_value,
+                display_total_chars_per_hour,
             ]
         )
 

--- a/tests/analysis/test_excel_na.py
+++ b/tests/analysis/test_excel_na.py
@@ -1,0 +1,84 @@
+import os
+import tempfile
+
+from openpyxl import load_workbook
+
+from genai_bench.analysis.excel_report import create_workbook
+from genai_bench.metrics.metrics import AggregatedMetrics, MetricStats, StatField
+from genai_bench.protocol import ExperimentMetadata
+
+
+def _make_metadata(scenarios: list[str]) -> ExperimentMetadata:
+    return ExperimentMetadata(
+        cmd="genai-bench benchmark",
+        benchmark_version="test",
+        api_backend="openai",
+        auth_config={},
+        api_model_name="gpt-3.5",
+        model="gpt-3.5",
+        task="text-to-text",
+        num_concurrency=[1],
+        batch_size=None,
+        iteration_type="num_concurrency",
+        traffic_scenario=scenarios,
+        additional_request_params={},
+        server_engine="engine",
+        server_version="v1",
+        server_gpu_type="A100",
+        server_gpu_count="1",
+        max_time_per_run_s=60,
+        max_requests_per_run=10,
+        experiment_folder_name="/tmp",
+        dataset_path=None,
+        character_token_ratio=1.0,
+    )
+
+
+def _agg_metrics(
+    scenario: str, num_concurrency: int, output_infer_speed_mean: float
+) -> AggregatedMetrics:
+    stats = MetricStats(output_inference_speed=StatField(mean=output_infer_speed_mean))
+    return AggregatedMetrics(
+        scenario=scenario,
+        num_concurrency=num_concurrency,
+        iteration_type="num_concurrency",
+        stats=stats,
+    )
+
+
+def test_summary_displays_na_when_threshold_not_met():
+    scenario = "D(100,100)"
+    metadata = _make_metadata([scenario])
+
+    # Build run_data where no iteration exceeds threshold (10 tokens/s)
+    # Provide a dummy individual_request_metrics entry to avoid empty merge ranges
+    run_data = {
+        scenario: {
+            1: {
+                "aggregated_metrics": _agg_metrics(
+                    scenario, 1, output_infer_speed_mean=5.0
+                ),
+                "individual_request_metrics": [{}],
+            }
+        }
+    }
+
+    with tempfile.TemporaryDirectory() as td:
+        out_path = os.path.join(td, "summary.xlsx")
+        create_workbook(metadata, run_data, out_path, percentile="mean")
+
+        wb = load_workbook(out_path)
+        ws = wb["Summary"]
+
+        # Find the row for our scenario
+        display_scenario = "Scenario 2: Chatbot/Dialog D(100,100)"
+        found = False
+        for row in ws.iter_rows(min_row=2, values_only=True):
+            # Columns: [GPU Type, Use Case, Summary Value, Total Chars/Hour]
+            if row[1] == display_scenario:
+                assert row[2] == "N/A"
+                assert row[3] == "N/A"
+                found = True
+                break
+
+        assert found, "Scenario row not found in Summary sheet"


### PR DESCRIPTION
## Issue
When benchmarking scenarios fail to meet the minimum output inference speed requirement (10 tokens/s for text tasks, 100 tokens/s for embedding tasks), the Excel summary report displayed a confusing sentinel value (-9999) instead of a user-friendly indication. This made it difficult for users to understand when their benchmarks didn't meet performance expectations.

## Modifications
- logged warning and display N/A when the speed requirement is not met
- Added unit test 