### PR TITLE
bugfix: Bring back HF dataset logging and scenario for images

### DIFF
--- a/genai_bench/cli/__init__.py
+++ b/genai_bench/cli/__init__.py
@@ -1,3 +1,0 @@
-from genai_bench.cli.utils import set_environment_variables
-
-set_environment_variables()

--- a/genai_bench/cli/utils.py
+++ b/genai_bench/cli/utils.py
@@ -1,6 +1,5 @@
 from locust.env import Environment
 
-import os
 import time
 from datetime import datetime
 from pathlib import Path
@@ -116,14 +115,3 @@ def get_run_params(iteration_type: str, iteration_value: int) -> Tuple[str, int,
     if iteration_type == "batch_size":
         return "Batch Size", iteration_value, 1
     return "Concurrency", 1, iteration_value
-
-
-def set_environment_variables():
-    """
-    Set environment variables for 3p libraries.
-    """
-    # Huggingface dataset library produces progress bar that is not desirable
-    os.environ["HF_DATASETS_DISABLE_PROGRESS_BARS"] = "1"
-
-    # Huggingface tokenizer library produces progress bar that is not desirable
-    os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"

--- a/genai_bench/cli/validation.py
+++ b/genai_bench/cli/validation.py
@@ -42,6 +42,13 @@ DEFAULT_SCENARIOS_FOR_CHAT = [
     "D(7800,200)",
 ]
 
+
+DEFAULT_SCENARIOS_FOR_VISION = [
+    "I(512,512)",
+    "I(1024,512)",
+    "I(2048,2048)",
+]
+
 DEFAULT_SCENARIOS_FOR_EMBEDDING = [
     "E(64)",
     "E(128)",
@@ -63,7 +70,9 @@ DEFAULT_SCENARIOS_FOR_RERANK = [
 DEFAULT_SCENARIOS_BY_TASK = {
     "text-to-text": DEFAULT_SCENARIOS_FOR_CHAT,
     "text-to-rerank": DEFAULT_SCENARIOS_FOR_RERANK,
+    "image-text-to-text": DEFAULT_SCENARIOS_FOR_VISION,
     "text-to-embeddings": DEFAULT_SCENARIOS_FOR_EMBEDDING,
+    "image-to-embeddings": DEFAULT_SCENARIOS_FOR_VISION,
     # add other tasks and default scenarios as needed
 }
 

--- a/genai_bench/sampling/image.py
+++ b/genai_bench/sampling/image.py
@@ -42,7 +42,7 @@ class ImageSampler(Sampler):
         super().__init__(tokenizer, model, output_modality, additional_request_params)
         self.data = data
 
-    def sample(self, scenario: Optional[Scenario] = None) -> UserRequest:
+    def sample(self, scenario: Scenario) -> UserRequest:
         """
         Samples a request based on the scenario or dataset configuration.
 
@@ -53,17 +53,9 @@ class ImageSampler(Sampler):
         Returns:
             UserRequest: A request object for the task.
         """
-        if scenario is not None:
-            self._validate_scenario(scenario)
-            image_dimension, num_images, num_output_tokens = scenario.sample()
-            prompt, image_content = self._sample_image_and_text(
-                image_dimension, num_images
-            )
-        else:
-            # Dataset-only mode
-            prompt, image_content = self._sample_image_and_text()
-            num_images = len(image_content)
-            num_output_tokens = None
+        self._validate_scenario(scenario)
+        image_dimension, num_images, num_output_tokens = scenario.sample()
+        prompt, image_content = self._sample_image_and_text(image_dimension, num_images)
 
         # TODO: create Delegated Request Creator to replace if-else
         if self.output_modality == "text":

--- a/tests/sampling/test_image.py
+++ b/tests/sampling/test_image.py
@@ -86,7 +86,3 @@ def test_image_sampler_with_invalid_scenario(mock_tokenizer, mock_vision_dataset
         match="Expected MultiModality for image tasks, got <class 'str'>",
     ):
         sampler.sample(mock_scenario)
-
-    # None scenario is now supported (dataset-only mode)
-    request = sampler.sample(None)
-    assert request is not None


### PR DESCRIPTION
## Motivations

- genai-bench is currently relying on scenario to control the whole benchmark logic.
- Allowing traffic-scenario to be None brings the overall complexity in the flow.
- Revert the changes in ImageSampler to allow None traffic scenario for now until we have a better design.
- HF dataset logging is useful at the beginning of the benchmark, bring it back.

## Modifications

- Revert the changes that allow `traffic scenario` to be `None` for `ImageSampler`.
- Add back `DEFAULT_SCENARIOS_FOR_VISION`
- Remove `set_environment_variables()`