### PR TITLE
feat: remove use_scenario, add DatasetScenario, make traffic scenario optional

### DIFF
--- a/genai_bench/cli/cli.py
+++ b/genai_bench/cli/cli.py
@@ -274,7 +274,7 @@ def benchmark(
         )
 
     # Load data using the factory
-    data, use_scenario = DataLoaderFactory.load_data_for_task(task, dataset_config_obj)
+    data = DataLoaderFactory.load_data_for_task(task, dataset_config_obj)
 
     # Create sampler with preloaded data
     sampler = Sampler.create(
@@ -282,17 +282,16 @@ def benchmark(
         tokenizer=tokenizer,
         model=api_model_name,
         data=data,
-        use_scenario=use_scenario,
         additional_request_params=additional_request_params,
     )
 
-    if not sampler.use_scenario:
+    # If user did not provide scenarios but provided a dataset, default to dataset mode
+    if not traffic_scenario and (dataset_path or dataset_config):
         logger.info(
-            f"No traffic scenario needed for dataset source type "
-            f"{dataset_config_obj.source.type} and task {task}. Setting scenario to a "
-            f"no-op placeholder 'F' (No Effect)."
+            "No traffic scenarios provided. Using dataset mode: sample raw entries "
+            "from the dataset."
         )
-        traffic_scenario = ["F"]
+        traffic_scenario = ["dataset"]
 
     max_time_per_run *= 60
 

--- a/genai_bench/cli/validation.py
+++ b/genai_bench/cli/validation.py
@@ -135,6 +135,9 @@ def validate_traffic_scenario_callback(ctx, param, value):
         )
     if value:
         return [validate_scenario_callback(v) for v in value]
+    # If user provided a dataset and no scenario, prefer dataset mode (no data shaping)
+    if ctx.params.get("dataset_path") or ctx.params.get("dataset_config"):
+        return ["dataset"]
     if task not in DEFAULT_SCENARIOS_BY_TASK:
         raise click.BadParameter(
             f"No default traffic scenarios defined for task '{task}'"

--- a/genai_bench/data/loaders/factory.py
+++ b/genai_bench/data/loaders/factory.py
@@ -1,9 +1,8 @@
 """Factory for creating appropriate data loaders and loading data."""
 
-from pathlib import Path
 from typing import Any, List, Tuple, Union, cast
 
-from genai_bench.data.config import DatasetConfig, DatasetSourceConfig
+from genai_bench.data.config import DatasetConfig
 from genai_bench.data.loaders.image import ImageDatasetLoader
 from genai_bench.data.loaders.text import TextDatasetLoader
 from genai_bench.logging import init_logger
@@ -17,7 +16,7 @@ class DataLoaderFactory:
     @staticmethod
     def load_data_for_task(
         task: str, dataset_config: DatasetConfig
-    ) -> Tuple[Union[List[str], List[Tuple[str, Any]]], bool]:
+    ) -> Union[List[str], List[Tuple[str, Any]]]:
         """Load data for a specific task.
 
         Args:
@@ -25,7 +24,7 @@ class DataLoaderFactory:
             dataset_config: Dataset configuration
 
         Returns:
-            Tuple of (loaded_data, use_scenario)
+            Loaded data for the task
         """
         input_modality, output_modality = task.split("-to-")
 
@@ -39,47 +38,21 @@ class DataLoaderFactory:
     @staticmethod
     def _load_text_data(
         dataset_config: DatasetConfig, output_modality: str
-    ) -> Tuple[List[str], bool]:
-        """Load text data with embeddings restrictions."""
-        # Handle embeddings restriction for non-sonnet datasets
-        is_sonnet = (
-            "sonnet" in dataset_config.source.path
-            if dataset_config.source.path
-            else False
-        )
-
-        if not is_sonnet and output_modality == "embeddings":
-            logger.warning(
-                "Embeddings currently do not support user-specified datasets. "
-                "Using the default `sonnet.txt` dataset."
-            )
-            # Create a new config with default sonnet path
-            sonnet_path = str(Path(__file__).parent.parent / "sonnet.txt")
-            dataset_config = DatasetConfig(
-                source=DatasetSourceConfig(
-                    type="file", path=sonnet_path, file_format="txt"
-                )  # type: ignore[call-arg]
-            )
+    ) -> List[str]:
+        """Load text data."""
 
         loader = TextDatasetLoader(dataset_config)
         data = loader.load_request()
 
         # TextDatasetLoader always returns List[str]
         text_data = cast(List[str], data)
-
-        # Determine if we should use scenario-based sampling
-        use_scenario = (
-            dataset_config.source.type == "file"
-            and dataset_config.source.file_format == "txt"
-        )
-
-        return text_data, use_scenario
+        return text_data
 
     @staticmethod
     def _load_image_data(
         dataset_config: DatasetConfig,
-    ) -> Tuple[List[Tuple[str, Any]], bool]:
+    ) -> List[Tuple[str, Any]]:
         """Load image data."""
         loader = ImageDatasetLoader(dataset_config)
         data = loader.load_request()
-        return data, True  # type: ignore
+        return data  # type: ignore

--- a/genai_bench/distributed/runner.py
+++ b/genai_bench/distributed/runner.py
@@ -30,7 +30,11 @@ class DistributedConfig:
     master_host: str = "127.0.0.1"
     master_port: int = 5557
     wait_time: int = 2
-    pin_to_cores: bool = True  # Enable CPU pinning by default
+
+    # Experimental:
+    # CPU pinning is not supported on all platforms, so we disable it by default
+    # If you want to enable it, you may need to set the cpu_affinity_map
+    pin_to_cores: bool = False
     cpu_affinity_map: Optional[Dict[int, int]] = None  # Custom worker->CPU mapping
 
     def __post_init__(self):
@@ -243,6 +247,7 @@ class DistributedRunner:
 
     def _set_cpu_affinity(self, worker_id: int) -> None:
         """Set CPU affinity for worker process"""
+        # NOTE: only works on Linux
         process = psutil.Process()
         cpu_count = multiprocessing.cpu_count()
 

--- a/genai_bench/sampling/base.py
+++ b/genai_bench/sampling/base.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional, Set, Type
 from transformers import PreTrainedTokenizer
 
 from genai_bench.protocol import UserRequest
-from genai_bench.scenarios.base import Scenario
+from genai_bench.scenarios.base import DatasetScenario, Scenario
 
 
 class Sampler(ABC):
@@ -51,8 +51,18 @@ class Sampler(ABC):
         self.get_token_length = lambda text, add_special_tokens=False: len(
             tokenizer.encode(text, add_special_tokens=add_special_tokens)
         )
-        self.use_scenario = True
         self.batch_size = 1  # Default batch size
+
+    def _is_dataset_mode(self, scenario: Optional[Scenario]) -> bool:
+        """Return True when sampler should use raw dataset without token shaping.
+
+        Dataset mode is signaled by a None scenario or a Scenario whose
+        string representation equals "dataset" (and for safety, by explicit
+        DatasetScenario instance).
+        """
+        if scenario is None:
+            return True
+        return isinstance(scenario, DatasetScenario)
 
     @abstractmethod
     def sample(self, scenario: Scenario) -> UserRequest:

--- a/genai_bench/sampling/image.py
+++ b/genai_bench/sampling/image.py
@@ -42,7 +42,7 @@ class ImageSampler(Sampler):
         super().__init__(tokenizer, model, output_modality, additional_request_params)
         self.data = data
 
-    def sample(self, scenario: Scenario) -> UserRequest:
+    def sample(self, scenario: Optional[Scenario]) -> UserRequest:
         """
         Samples a request based on the scenario or dataset configuration.
 
@@ -53,8 +53,12 @@ class ImageSampler(Sampler):
         Returns:
             UserRequest: A request object for the task.
         """
-        self._validate_scenario(scenario)
-        image_dimension, num_images, num_output_tokens = scenario.sample()
+        # Dataset mode when scenario is dataset or None
+        if self._is_dataset_mode(scenario):
+            image_dimension, num_images, num_output_tokens = None, 1, None
+        else:
+            self._validate_scenario(scenario)
+            image_dimension, num_images, num_output_tokens = scenario.sample()
         prompt, image_content = self._sample_image_and_text(image_dimension, num_images)
 
         # TODO: create Delegated Request Creator to replace if-else

--- a/genai_bench/scenarios/__init__.py
+++ b/genai_bench/scenarios/__init__.py
@@ -1,6 +1,7 @@
 """Scenario definitions for traffic generation."""
 
 from genai_bench.scenarios.base import (
+    DatasetScenario,
     EmbeddingDistribution,
     MultiModality,
     ReRankDistribution,
@@ -18,6 +19,7 @@ __all__ = [
     "EmbeddingDistribution",
     "EmbeddingScenario",
     "ImageModality",
+    "DatasetScenario",
     "MultiModality",
     "NormalDistribution",
     "ReRankDistribution",

--- a/genai_bench/scenarios/base.py
+++ b/genai_bench/scenarios/base.py
@@ -12,7 +12,6 @@ class TextDistribution(Enum):
     NORMAL = "N"
     DETERMINISTIC = "D"
     UNIFORM = "U"
-    FILE = "F"  # Special case within text distribution
 
 
 class EmbeddingDistribution(Enum):
@@ -41,6 +40,12 @@ class MultiModality(Enum):
     AUDIO = "A"
 
 
+class SpecialScenario(Enum):
+    """Special, non-parametric scenario types."""
+
+    DATASET = "dataset"
+
+
 class Scenario(ABC):
     """
     An abstract base class for different scenarios based on specified
@@ -49,7 +54,11 @@ class Scenario(ABC):
 
     _registry: Dict[str, Type["Scenario"]] = {}
     scenario_type: (
-        TextDistribution | MultiModality | EmbeddingDistribution | ReRankDistribution
+        TextDistribution
+        | MultiModality
+        | EmbeddingDistribution
+        | ReRankDistribution
+        | SpecialScenario
     )
     validation_pattern: str
 
@@ -85,13 +94,17 @@ class Scenario(ABC):
         representation.
         Determines the correct subclass to instantiate using the registered map.
         """
+        # Extract leading type token (supports multi-char tokens like "dataset")
+        match = re.match(r"^([A-Za-z]+)", scenario_str)
+        type_token = match.group(1) if match else scenario_str[0]
         cls.validate(scenario_str)
-        type_identifier = scenario_str[0]
-        scenario_class = cls._registry.get(type_identifier)
+        scenario_class = cls._registry.get(type_token)
         assert (
             scenario_class is not None
         ), "scenario_class should not be None at this step"
-        return scenario_class.parse(scenario_str[1:])
+        # Pass the parameter substring (if any) to parser
+        params_str = scenario_str[len(type_token) :]
+        return scenario_class.parse(params_str)
 
     @classmethod
     def validate(cls, scenario_str: str) -> bool:
@@ -99,22 +112,45 @@ class Scenario(ABC):
         Scenario string validation method
         Subclass requires validation_pattern to be defined
         """
-        scenario_type = scenario_str[0]
-        scenario_class = cls._registry.get(scenario_type)
-        if not scenario_class or not bool(
-            re.match(scenario_class.validation_pattern, scenario_str)
-        ):
+        match = re.match(r"^([A-Za-z]+)", scenario_str)
+        type_token = match.group(1) if match else scenario_str[0]
+        scenario_class = cls._registry.get(type_token)
+        if not scenario_class:
+            supported = ", ".join(sorted(cls._registry.keys()))
             raise ValueError(
-                f"Invalid scenario string '{scenario_str}'. Should follow "
-                "U(min_input_tokens,max_input_tokens)/(min_output_tokens,max_output_tokens), "  # noqa: E501
-                "N(mean_input_tokens,stddev_input_tokens)/(mean_output_tokens,stddev_output_tokens), "  # noqa: E501
-                "D(num_input_tokens,num_output_tokens), "
-                "U(max_input_tokens,max_output_tokens) OR "
-                "Multi modality scenario I(num_input_dimension_width,num_input_dimension_height,num_input_images)"  # noqa: E501
-                "Embedding scenario: E(max_tokens_per_document)"
-                "Re-Rank scenario: R(max_tokens_per_document,max_tokens_per_query)"
+                f"Invalid scenario string '{scenario_str}'. Unknown type "
+                f"'{type_token}'. Supported types: {supported}"
+            )
+        if not re.match(scenario_class.validation_pattern, scenario_str):
+            raise ValueError(
+                f"Invalid scenario string '{scenario_str}' for type '{type_token}'. "
+                f"Expected to match pattern: {scenario_class.validation_pattern}"
             )
         return True
+
+
+class DatasetScenario(Scenario):
+    """
+    A generic no-op scenario used to indicate dataset/direct sampling mode.
+    Not registered in the scenario registry; created via human-friendly alias
+    in Scenario.from_string (e.g., "dataset").
+    """
+
+    scenario_type = SpecialScenario.DATASET
+    validation_pattern = r"^dataset$"
+
+    def sample(self) -> Any:  # pragma: no cover
+        raise NotImplementedError(
+            "DatasetScenario has no sampling parameters; samplers should bypass token "
+            "shaping in dataset mode."
+        )
+
+    def to_string(self) -> str:
+        return "dataset"
+
+    @classmethod
+    def parse(cls, params_str: str) -> "Scenario":
+        return cls()
 
 
 def parse_params_str(

--- a/genai_bench/scenarios/text.py
+++ b/genai_bench/scenarios/text.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Tuple
+from typing import Optional, Tuple
 
 import numpy as np
 
@@ -155,30 +155,6 @@ class DeterministicDistribution(Scenario):
             num_input_tokens=num_input,
             num_output_tokens=num_output,
         )
-
-
-class NoOpScenario(Scenario):
-    """
-    A scenario that effectively performs no operation. Can be used for
-    placeholders in various contexts. For example, when no input/output
-    token sampling is required.
-
-    e.g.
-    F
-    """
-
-    scenario_type = TextDistribution.FILE
-    validation_pattern = r"F$"
-
-    def sample(self) -> Tuple[Any, Any]:
-        return None, None
-
-    def to_string(self) -> str:
-        return "F"
-
-    @classmethod
-    def parse(cls, params_str: str) -> "NoOpScenario":
-        return NoOpScenario()
 
 
 class EmbeddingScenario(Scenario):

--- a/tests/cli/test_validation.py
+++ b/tests/cli/test_validation.py
@@ -321,6 +321,11 @@ def test_validate_traffic_scenarios():
         exc.value
     )
 
+    # Test with dataset-mode
+    ctx.params = {"task": "text-to-text", "dataset_path": "path/to/dataset"}
+    result = validate_traffic_scenario_callback(ctx, param, None)
+    assert result == ["dataset"]
+
 
 def test_validate_iteration_params():
     """Test validation of iteration parameters for different tasks."""

--- a/tests/data/loaders/test_factory.py
+++ b/tests/data/loaders/test_factory.py
@@ -23,35 +23,9 @@ def test_load_data_for_text_task():
         mock_loader.load_request.return_value = ["text1", "text2"]
         mock_loader_class.return_value = mock_loader
 
-        data, use_scenario = DataLoaderFactory.load_data_for_task(
-            "text-to-text", config
-        )
+        data = DataLoaderFactory.load_data_for_task("text-to-text", config)
 
         assert data == ["text1", "text2"]
-        assert use_scenario is True  # txt files use scenario-based sampling
-
-
-def test_load_data_for_embeddings_with_non_sonnet():
-    """Test loading data for embeddings task with non-sonnet dataset."""
-    config = DatasetConfig(
-        source=DatasetSourceConfig(type="huggingface", path="other/dataset")
-    )
-
-    with patch(
-        "genai_bench.data.loaders.factory.TextDatasetLoader"
-    ) as mock_loader_class:
-        mock_loader = MagicMock()
-        mock_loader.load_request.return_value = ["text1", "text2"]
-        mock_loader_class.return_value = mock_loader
-
-        data, use_scenario = DataLoaderFactory.load_data_for_task(
-            "text-to-embeddings", config
-        )
-
-        # Should use sonnet.txt for embeddings
-        assert mock_loader_class.call_count == 1
-        created_config = mock_loader_class.call_args[0][0]
-        assert "sonnet.txt" in created_config.source.path
 
 
 def test_load_data_for_image_task():
@@ -70,12 +44,9 @@ def test_load_data_for_image_task():
         ]
         mock_loader_class.return_value = mock_loader
 
-        data, use_scenario = DataLoaderFactory.load_data_for_task(
-            "image-text-to-text", config
-        )
+        data = DataLoaderFactory.load_data_for_task("image-text-to-text", config)
 
         assert data == [("prompt1", "image1"), ("prompt2", "image2")]
-        assert use_scenario is True  # images use scenario-based sampling
 
 
 def test_load_data_for_invalid_task():

--- a/tests/sampling/test_base.py
+++ b/tests/sampling/test_base.py
@@ -28,7 +28,6 @@ def test_sampler_factory(mock_vision_dataset):
         tokenizer=Mock(),
         model="gpt-3",
         data=text_data,
-        use_scenario=True,
     )
     assert isinstance(sampler, TextSampler)
 
@@ -37,7 +36,6 @@ def test_sampler_factory(mock_vision_dataset):
         tokenizer=Mock(),
         model="gpt-3",
         data=text_data,
-        use_scenario=True,
     )
     assert isinstance(sampler, TextSampler)
 
@@ -46,7 +44,6 @@ def test_sampler_factory(mock_vision_dataset):
         tokenizer=Mock(),
         model="gpt-3",
         data=mock_vision_dataset,
-        use_scenario=False,
     )
     assert isinstance(sampler, ImageSampler)
 

--- a/tests/sampling/test_text.py
+++ b/tests/sampling/test_text.py
@@ -7,7 +7,7 @@ from genai_bench.protocol import (
     UserReRankRequest,
 )
 from genai_bench.sampling.text import TextSampler
-from genai_bench.scenarios import EmbeddingScenario, NormalDistribution
+from genai_bench.scenarios import DatasetScenario, EmbeddingScenario, NormalDistribution
 from genai_bench.scenarios.text import ReRankScenario
 
 
@@ -23,7 +23,6 @@ class TestTextSampler(unittest.TestCase):
             model=self.model,
             output_modality=self.output_modality,
             data=self.test_data,
-            use_scenario=True,
         )
 
     def test_check_discrepancy(self):
@@ -83,16 +82,9 @@ class TestTextSampler(unittest.TestCase):
             model=self.model,
             output_modality=self.output_modality,
             data=self.test_data,
-            use_scenario=False,
         )
         self.tokenizer.encode.return_value = [1, 2, 3, 4, 5]
-        scenario = NormalDistribution(
-            mean_input_tokens=10,
-            stddev_input_tokens=2,
-            mean_output_tokens=20,
-            stddev_output_tokens=5,
-        )
-
+        scenario = DatasetScenario()
         request = no_scenario_sampler.sample(scenario)
 
         self.assertIsInstance(request, UserChatRequest)

--- a/tests/scenarios/test_base.py
+++ b/tests/scenarios/test_base.py
@@ -1,11 +1,10 @@
 import pytest
 
-from genai_bench.scenarios import ImageModality
+from genai_bench.scenarios import DatasetScenario, ImageModality
 from genai_bench.scenarios.base import Scenario
 from genai_bench.scenarios.text import (
     DeterministicDistribution,
     EmbeddingScenario,
-    NoOpScenario,
     NormalDistribution,
     ReRankScenario,
     UniformDistribution,
@@ -229,25 +228,20 @@ def test_scenario_to_string():
     assert scenario.to_string() == "R(1024,100)"
 
 
-def test_scenario_from_string_file():
-    scenario = Scenario.from_string("F")
-    assert isinstance(scenario, NoOpScenario)
+def test_dataset_scenario_from_string():
+    scenario = Scenario.from_string("dataset")
+    assert isinstance(scenario, DatasetScenario)
 
 
-def test_file_distribution_sample():
-    scenario = NoOpScenario()
-    sample = scenario.sample()
-    assert sample == (None, None)
+def test_dataset_scenario_sample():
+    scenario = DatasetScenario()
+    with pytest.raises(NotImplementedError):
+        _ = scenario.sample()
 
 
-def test_file_distribution_to_string():
-    scenario = NoOpScenario()
-    assert scenario.to_string() == "F"
-
-
-def test_file_distribution_parse():
-    scenario = NoOpScenario.parse("F")
-    assert isinstance(scenario, NoOpScenario)
+def test_dataset_scenario_to_string():
+    scenario = DatasetScenario()
+    assert scenario.to_string() == "dataset"
 
 
 def test_rerank_from_string():

--- a/tests/scenarios/test_text.py
+++ b/tests/scenarios/test_text.py
@@ -3,7 +3,6 @@
 from genai_bench.scenarios.text import (
     DeterministicDistribution,
     EmbeddingScenario,
-    NoOpScenario,
     NormalDistribution,
     ReRankScenario,
     UniformDistribution,
@@ -69,14 +68,6 @@ def test_rerank_scenario():
     assert query_tokens == 64
 
 
-def test_noop_scenario():
-    """Test NoOpScenario."""
-    scenario = NoOpScenario()
-
-    result = scenario.sample()
-    assert result == (None, None)
-
-
 def test_normal_distribution_to_string():
     """Test NormalDistribution string representation."""
     scenario = NormalDistribution(
@@ -118,9 +109,3 @@ def test_rerank_scenario_to_string():
     """Test ReRankScenario string representation."""
     scenario = ReRankScenario(tokens_per_document=1024, tokens_per_query=100)
     assert scenario.to_string() == "R(1024,100)"
-
-
-def test_noop_scenario_to_string():
-    """Test NoOpScenario string representation."""
-    scenario = NoOpScenario()
-    assert scenario.to_string() == "F"


### PR DESCRIPTION
## Motivation

- The `use_scenario` flag leaked loader policy into samplers/CLI and blocked legitimate use-cases (e.g., using scenarios with CSV/JSON/HF datasets).
- Users expect “no scenarios provided + dataset present” to run the dataset directly without token shaping.
- The legacy “F” sentinel was unclear; we needed a user-friendly, first-class representation.

## Modifications
- Traffic scenarios are optional end-to-end
  - When no `--traffic-scenario` is passed and a dataset is provided, we default to dataset mode (“dataset”) without token shaping.
  - We keep the existing scenario-driven benchmark loop unchanged by injecting a single dataset sentinel (“dataset”) when needed.

- `use_scenario` removed
  - Deleted the `use_scenario` flag from loaders, CLI, and samplers.
  - `DataLoaderFactory` now only returns loaded data (no policy-bit alongside).
  - `Sampler` and `TextSampler` no longer accept/use use_scenario.

- Introduced `DatasetScenario` as a first-class scenario
  - Added `SpecialScenario.DATASET` enum.
  - Removed the opaque “F” alias everywhere.

- Sampler refactor for dataset mode
  - Added `Sampler.is_dataset_mode(scenario)` to detect dataset/direct sampling without try/except or registry hacks.

- CLI and validation
  - CLI: if no `--traffic-scenario` and a dataset is present, we inject `["dataset"]` and log that we’ll sample raw entries.
  - Validation: if dataset provided and no scenarios passed, return `["dataset"]` so CLI can inject dataset mode; otherwise use defaults for that task.

- Embeddings restriction removed
  - Removed “sonnet-only” override for text-to-embeddings. Users can now use any dataset for embeddings.

- Tests updated

- Remove `pin_to_core` in `DistributedRunner` as it is not supported on all platforms. And Linux should have a better kernel to handle this.