### PR TITLE
feat(data): normalize HF dataset types and enable lazy image sampling

### DIFF
--- a/genai_bench/cli/cli.py
+++ b/genai_bench/cli/cli.py
@@ -372,9 +372,6 @@ def benchmark(
     # and run the experiment
     iteration_values = batch_size if iteration_type == "batch_size" else num_concurrency
     total_runs = len(traffic_scenario) * len(iteration_values)
-
-    # Switch logging into Live mode right before creating the Live screen
-    logging_manager.enter_live_mode()
     with dashboard.live:
         for scenario_str in traffic_scenario:
             dashboard.reset_plot_metrics()

--- a/genai_bench/cli/cli.py
+++ b/genai_bench/cli/cli.py
@@ -283,6 +283,7 @@ def benchmark(
         model=api_model_name,
         data=data,
         additional_request_params=additional_request_params,
+        dataset_config=dataset_config_obj,
     )
 
     # If user did not provide scenarios but provided a dataset, default to dataset mode

--- a/genai_bench/cli/cli.py
+++ b/genai_bench/cli/cli.py
@@ -371,6 +371,9 @@ def benchmark(
     # and run the experiment
     iteration_values = batch_size if iteration_type == "batch_size" else num_concurrency
     total_runs = len(traffic_scenario) * len(iteration_values)
+
+    # Switch logging into Live mode right before creating the Live screen
+    logging_manager.enter_live_mode()
     with dashboard.live:
         for scenario_str in traffic_scenario:
             dashboard.reset_plot_metrics()

--- a/genai_bench/data/config.py
+++ b/genai_bench/data/config.py
@@ -100,7 +100,7 @@ class DatasetConfig(BaseModel):
                     file_format = "csv"
                 elif path.suffix == ".txt":
                     file_format = "txt"
-                else:
+                elif path.suffix == ".json":
                     file_format = "json"
             else:
                 # Assume it's a HuggingFace ID

--- a/genai_bench/data/config.py
+++ b/genai_bench/data/config.py
@@ -102,6 +102,8 @@ class DatasetConfig(BaseModel):
                     file_format = "txt"
                 elif path.suffix == ".json":
                     file_format = "json"
+                else:
+                    raise ValueError(f"Unsupported file format: {path.suffix}")
             else:
                 # Assume it's a HuggingFace ID
                 source_type = "huggingface"

--- a/genai_bench/logging.py
+++ b/genai_bench/logging.py
@@ -111,6 +111,7 @@ class LoggingManager:
         self.layout = layout
         self.live = live
         self.delayed_handler = None
+        self.console_handler = None
         self.init_logging()
 
     def init_logging(self):
@@ -195,7 +196,14 @@ class LoggingManager:
         return rich_handler
 
     def init_ui_logging(self):
-        """Initialize UI logging handlers for 'benchmark'."""
+        """Initialize UI logging handlers for 'benchmark'.
+
+        Strategy:
+        - Before entering Live dashboard: attach console + panel handlers so logs
+          appear immediately in terminal and are mirrored to the dashboard's log panel.
+        - When entering Live dashboard: swap console handler for a delayed handler
+          that buffers logs and flushes them after the dashboard exits.
+        """
         date_format = "%Y-%m-%d %H:%M:%S.%f"
 
         # Panel handler to stream logs to the logs panel in dashboard
@@ -209,7 +217,10 @@ class LoggingManager:
         )
         panel_handler.setFormatter(panel_formatter)
 
-        # Delayed handler to flush logs after dashboard exits
+        # Console handler for immediate terminal output BEFORE Live starts
+        self.console_handler = self.get_console_handler()
+
+        # Prepare (but do not attach yet) delayed handler for AFTER Live starts
         self.delayed_handler = DelayedRichHandler(
             live=self.live,
             console=Console(),
@@ -218,7 +229,23 @@ class LoggingManager:
         delayed_formatter = logging.Formatter("%(message)s", style="%")
         self.delayed_handler.setFormatter(delayed_formatter)
 
-        return [panel_handler, self.delayed_handler]
+        # Attach panel + console initially
+        return [panel_handler, self.console_handler]
+
+    def enter_live_mode(self):
+        """Switch logging to Live dashboard mode.
+
+        - Remove console handler to avoid interfering with Live output.
+        - Attach delayed handler to buffer logs and flush them after Live exits.
+        """
+        root_logger = logging.getLogger()
+        # Detach console handler if present
+        if self.console_handler and self.console_handler in root_logger.handlers:
+            root_logger.removeHandler(self.console_handler)
+
+        # Attach delayed handler if not already attached
+        if self.delayed_handler and self.delayed_handler not in root_logger.handlers:
+            root_logger.addHandler(self.delayed_handler)
 
 
 class WorkerLoggingManager:

--- a/genai_bench/sampling/base.py
+++ b/genai_bench/sampling/base.py
@@ -30,6 +30,7 @@ class Sampler(ABC):
         model: str,
         output_modality: str,
         additional_request_params: Optional[dict] = None,
+        dataset_config=None,
         **kwargs,
     ):
         """Initializes the Sampler.
@@ -52,6 +53,7 @@ class Sampler(ABC):
             tokenizer.encode(text, add_special_tokens=add_special_tokens)
         )
         self.batch_size = 1  # Default batch size
+        self.dataset_config = dataset_config
 
     def _is_dataset_mode(self, scenario: Optional[Scenario]) -> bool:
         """Return True when sampler should use raw dataset without token shaping.

--- a/genai_bench/sampling/base.py
+++ b/genai_bench/sampling/base.py
@@ -3,6 +3,7 @@ from typing import Dict, Optional, Set, Type
 
 from transformers import PreTrainedTokenizer
 
+from genai_bench.data.config import DatasetConfig
 from genai_bench.protocol import UserRequest
 from genai_bench.scenarios.base import DatasetScenario, Scenario
 
@@ -30,7 +31,7 @@ class Sampler(ABC):
         model: str,
         output_modality: str,
         additional_request_params: Optional[dict] = None,
-        dataset_config=None,
+        dataset_config: Optional[DatasetConfig] = None,
         **kwargs,
     ):
         """Initializes the Sampler.

--- a/genai_bench/sampling/image.py
+++ b/genai_bench/sampling/image.py
@@ -6,6 +6,7 @@ import PIL
 from PIL.Image import Image
 from six import BytesIO
 
+from genai_bench.data.config import DatasetConfig
 from genai_bench.logging import init_logger
 from genai_bench.protocol import (
     UserImageChatRequest,
@@ -37,6 +38,7 @@ class ImageSampler(Sampler):
         model: str,
         output_modality: str,
         data: Any,
+        dataset_config: Optional[DatasetConfig] = None,
         additional_request_params: Optional[dict] = None,
         **kwargs,
     ):
@@ -45,7 +47,7 @@ class ImageSampler(Sampler):
             model,
             output_modality,
             additional_request_params,
-            dataset_config=kwargs.get("dataset_config"),
+            dataset_config=dataset_config,
         )
         self.data = data
 

--- a/genai_bench/sampling/image.py
+++ b/genai_bench/sampling/image.py
@@ -14,6 +14,7 @@ from genai_bench.protocol import (
 )
 from genai_bench.sampling.base import Sampler
 from genai_bench.scenarios.base import MultiModality, Scenario
+from genai_bench.utils import safe_eval_prompt
 
 logger = init_logger(__name__)
 
@@ -35,11 +36,17 @@ class ImageSampler(Sampler):
         tokenizer,
         model: str,
         output_modality: str,
-        data: List[Tuple[str, Any]],
+        data: Any,
         additional_request_params: Optional[dict] = None,
         **kwargs,
     ):
-        super().__init__(tokenizer, model, output_modality, additional_request_params)
+        super().__init__(
+            tokenizer,
+            model,
+            output_modality,
+            additional_request_params,
+            dataset_config=kwargs.get("dataset_config"),
+        )
         self.data = data
 
     def sample(self, scenario: Optional[Scenario]) -> UserRequest:
@@ -140,33 +147,46 @@ class ImageSampler(Sampler):
         self, image_dimension: Optional[Tuple[int, int]] = None, num_images: int = 1
     ) -> Tuple[str, List[str]]:
         """
-        Loads and processes images and accompanying texts from the dataset.
+        Lazily sample and process images and accompanying texts from the dataset.
 
-        Args:
-            image_dimension (Tuple[int, int], optional): Dimensions to resize the
-                images.
-            num_images (int): Number of images to load. Defaults to 1.
-
-        Returns:
-            Tuple[str, List[str]]: A tuple containing:
-                - Texts concatenated as a single prompt.
-                - A list of image URLs (base64 data URLs or file:// URLs).
+        Supports two input shapes:
+        - Sequence of (prompt, image) tuples (backward compatible)
+        - Sequence of dict rows (e.g., HF Dataset rows) using dataset_config
         """
-        selected_data = random.choices(self.data, k=num_images)
-        images, texts = [], []
+        images: List[str] = []
+        texts: List[str] = []
 
-        for data in selected_data:
-            raw_image = data[1]
-            # Use process_image with resize parameter
+        chosen = random.choices(self.data, k=num_images)
+        for item in chosen:
+            prompt: str = ""
+            raw_image: Any = None
+            # Backward-compatible format
+            if isinstance(item, tuple) and len(item) == 2:
+                prompt, raw_image = item
+            # Dict row format
+            elif isinstance(item, dict) and self.dataset_config is not None:
+                cfg = self.dataset_config
+                if cfg.image_column:
+                    raw_image = item.get(cfg.image_column)
+                if cfg.prompt_lambda:
+                    prompt = safe_eval_prompt(cfg.prompt_lambda, item)
+                elif cfg.prompt_column:
+                    prompt = str(item.get(cfg.prompt_column, ""))
+            else:
+                continue
+
+            if raw_image is None:
+                continue
             processed_image = ImageSampler.process_image(
                 raw_image, resize=image_dimension
             )
             images.append(processed_image)
-            texts.append(data[0])
+            texts.append(prompt or "")
+
         return " ".join(texts), images
 
     @staticmethod
-    def process_image(image: Any, resize: tuple = None) -> str:
+    def process_image(image: Any, resize: Optional[Tuple[int, int]] = None) -> str:
         """
         Process a single image input and return a data URL or HTTP(S) URL.
 

--- a/genai_bench/sampling/text.py
+++ b/genai_bench/sampling/text.py
@@ -1,6 +1,7 @@
 import random
 from typing import Any, Dict, List, Optional
 
+from genai_bench.data.config import DatasetConfig
 from genai_bench.logging import init_logger
 from genai_bench.protocol import (
     UserChatRequest,
@@ -31,9 +32,12 @@ class TextSampler(Sampler):
         output_modality: str,
         data: List[str],
         additional_request_params: Optional[Dict[str, Any]] = None,
+        dataset_config: Optional[DatasetConfig] = None,
         **kwargs,
     ):
-        super().__init__(tokenizer, model, output_modality, additional_request_params)
+        super().__init__(
+            tokenizer, model, output_modality, additional_request_params, dataset_config
+        )
 
         self.data = data
         self.batch_size = 1  # Default batch size

--- a/genai_bench/utils.py
+++ b/genai_bench/utils.py
@@ -4,6 +4,10 @@ from pathlib import Path
 
 from transformers import PreTrainedTokenizer
 
+from genai_bench.logging import init_logger
+
+logger = init_logger(__name__)
+
 
 def sanitize_string(input_str: str):
     """
@@ -67,7 +71,10 @@ def safe_eval_prompt(prompt_template: str, item: dict) -> str:
             safe_dict = {"context": item, "str": str, "len": len}
             result = eval(expr, {"__builtins__": {}}, safe_dict)
             return str(result) if result is not None else ""
-        except Exception:
+        except Exception as e:
+            logger.warning(
+                f"Failed to evaluate prompt template: {prompt_template}, error: {e}"
+            )
             return ""
 
     # Simple field access

--- a/tests/data/loaders/test_image.py
+++ b/tests/data/loaders/test_image.py
@@ -1,191 +1,73 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from datasets import Dataset as HFDataset
+from datasets import DatasetDict as HFDatasetDict
+from datasets import IterableDataset as HFIterableDataset
 
 from genai_bench.data.config import DatasetConfig, DatasetSourceConfig
 from genai_bench.data.loaders.image import ImageDatasetLoader
 
 
 @pytest.fixture
-def mock_dataset():
-    # Create mock PIL Images instead of strings
-
-    from PIL import Image as PILImage
-
-    # Create fake image data
-    mock_image_1 = PILImage.new("RGB", (100, 100), color="red")
-    mock_image_2 = PILImage.new("RGB", (100, 100), color="blue")
-
-    mock_dataset = MagicMock()
-    mock_dataset.__len__.return_value = 2
-    mock_dataset.features = ["image_column", "prompt_column"]
-    mock_dataset.__iter__.return_value = iter(
-        [
-            {"image_column": mock_image_1, "prompt_column": "prompt_1"},
-            {"image_column": mock_image_2, "prompt_column": "prompt_2"},
-        ]
-    )
-    return mock_dataset
-
-
-@pytest.fixture
-def mock_empty_dataset():
-    return []
-
-
-@pytest.fixture
 def dataset_config():
     return DatasetConfig(
-        source=DatasetSourceConfig(
-            type="huggingface",
-            path="test/dataset",
-            huggingface_kwargs={"subset": None, "split": None, "revision": None},
-        ),
+        source=DatasetSourceConfig(type="huggingface", path="test/dataset"),
         prompt_column="prompt_column",
         image_column="image_column",
     )
 
 
 @patch("genai_bench.data.sources.DatasetSourceFactory.create")
-def test_load_requests_success(mock_factory, mock_dataset, dataset_config):
-    """Test if load_requests successfully loads image dataset"""
+def test_returns_hf_dataset_as_is(mock_factory, dataset_config):
+    ds = HFDataset.from_dict({"image_column": [1, 2], "prompt_column": ["a", "b"]})
     mock_source = MagicMock()
-    mock_source.load.return_value = mock_dataset
+    mock_source.load.return_value = ds
     mock_factory.return_value = mock_source
 
     results = ImageDatasetLoader(dataset_config).load_request()
-
-    # Check we got 2 results with correct prompts and PIL Images
+    assert isinstance(results, HFDataset)
     assert len(results) == 2
-    assert results[0][0] == "prompt_1"
-    assert results[1][0] == "prompt_2"
-    # Verify images are PIL Images
-    from PIL import Image as PILImage
-
-    assert isinstance(results[0][1], PILImage.Image)
-    assert isinstance(results[1][1], PILImage.Image)
 
 
 @patch("genai_bench.data.sources.DatasetSourceFactory.create")
-def test_load_requests_missing_prompt(mock_factory, mock_dataset, dataset_config):
-    """Test if load_requests handles missing prompt column"""
-    from PIL import Image as PILImage
-
-    mock_image_1 = PILImage.new("RGB", (100, 100), color="red")
-    mock_image_2 = PILImage.new("RGB", (100, 100), color="blue")
-
-    mock_dataset.__iter__.return_value = [
-        {"image_column": mock_image_1},
-        {"image_column": mock_image_2},
-    ]
+def test_selects_train_split_from_datasetdict(mock_factory, dataset_config):
+    train = HFDataset.from_dict({"image_column": [1], "prompt_column": ["t"]})
+    valid = HFDataset.from_dict({"image_column": [2], "prompt_column": ["v"]})
+    dd = HFDatasetDict({"train": train, "validation": valid})
     mock_source = MagicMock()
-    mock_source.load.return_value = mock_dataset
-    mock_factory.return_value = mock_source
-    dataset_config.prompt_column = None
-
-    results = ImageDatasetLoader(dataset_config).load_request()
-
-    # Check results have empty prompts and PIL Images
-    assert len(results) == 2
-    assert results[0][0] == ""
-    assert results[1][0] == ""
-    assert isinstance(results[0][1], PILImage.Image)
-    assert isinstance(results[1][1], PILImage.Image)
-
-
-@patch("genai_bench.data.sources.DatasetSourceFactory.create")
-def test_load_requests_empty_dataset(mock_factory, mock_empty_dataset, dataset_config):
-    """Test if load_requests handles empty dataset gracefully"""
-    mock_source = MagicMock()
-    mock_source.load.return_value = mock_empty_dataset
+    mock_source.load.return_value = dd
     mock_factory.return_value = mock_source
 
     results = ImageDatasetLoader(dataset_config).load_request()
-    assert results == []
+    assert isinstance(results, HFDataset)
+    assert len(results) == 1
+    assert results[0]["prompt_column"] == "t"
 
 
 @patch("genai_bench.data.sources.DatasetSourceFactory.create")
-def test_load_requests_override_prompt(mock_factory, mock_dataset, dataset_config):
-    """Test if load_requests uses prompt_lambda for fixed prompt"""
+def test_datasetdict_no_splits_raises(mock_factory, dataset_config):
+    dd = HFDatasetDict({})
     mock_source = MagicMock()
-    mock_source.load.return_value = mock_dataset
-    mock_factory.return_value = mock_source
-    dataset_config.prompt_lambda = 'lambda x: "Fixed prompt for all"'
-
-    results = ImageDatasetLoader(dataset_config).load_request()
-
-    # Check fixed prompt is used for all images
-    assert len(results) == 2
-    assert results[0][0] == "Fixed prompt for all"
-    assert results[1][0] == "Fixed prompt for all"
-    from PIL import Image as PILImage
-
-    assert isinstance(results[0][1], PILImage.Image)
-    assert isinstance(results[1][1], PILImage.Image)
-
-
-@patch("genai_bench.data.sources.DatasetSourceFactory.create")
-def test_load_requests_missing_prompt_column_in_data(mock_factory, dataset_config):
-    """Test if load_requests fails fast when prompt column doesn't exist in data"""
-    from PIL import Image as PILImage
-
-    mock_image_1 = PILImage.new("RGB", (100, 100), color="red")
-    mock_image_2 = PILImage.new("RGB", (100, 100), color="blue")
-
-    # Dataset items don't have the prompt column
-    mock_dataset = MagicMock()
-    mock_dataset.__iter__.return_value = iter(
-        [
-            {"image_column": mock_image_1, "other_column": "other_1"},
-            {"image_column": mock_image_2, "other_column": "other_2"},
-        ]
-    )
-    mock_source = MagicMock()
-    mock_source.load.return_value = mock_dataset
+    mock_source.load.return_value = dd
     mock_factory.return_value = mock_source
 
-    # Config specifies a prompt column that doesn't exist
-    dataset_config.prompt_column = "nonexistent_column"
-
-    # Should raise ValueError for missing column (fail fast)
-    with pytest.raises(ValueError, match="Cannot extract image data from dataset"):
+    with pytest.raises(ValueError, match="no splits to select"):
         ImageDatasetLoader(dataset_config).load_request()
 
 
 @patch("genai_bench.data.sources.DatasetSourceFactory.create")
-@patch("requests.get")
-@patch("PIL.Image.open")
-def test_load_requests_url_images(
-    mock_pil_open, mock_requests_get, mock_factory, dataset_config
-):
-    """Test if load_requests handles URL images"""
-    # Mock dataset with URL strings
-    mock_dataset = MagicMock()
-    mock_dataset.__iter__.return_value = iter(
-        [
-            {
-                "image_column": "https://example.com/image1.jpg",
-                "prompt_column": "prompt_1",
-            },
-            {
-                "image_column": "https://example.com/image2.jpg",
-                "prompt_column": "prompt_2",
-            },
-        ]
-    )
+def test_streaming_dataset_raises(mock_factory, dataset_config):
+    # Create a minimal IterableDataset if available; otherwise skip
+    if not hasattr(HFIterableDataset, "from_generator"):
+        pytest.skip(
+            "IterableDataset.from_generator not available in this datasets version"
+        )
+
+    ds = HFIterableDataset.from_generator(lambda: iter([]))
     mock_source = MagicMock()
-    mock_source.load.return_value = mock_dataset
+    mock_source.load.return_value = ds
     mock_factory.return_value = mock_source
 
-    results = ImageDatasetLoader(dataset_config).load_request()
-
-    # URLs are now passed through directly, not fetched
-    assert len(results) == 2
-    assert results[0][0] == "prompt_1"
-    assert results[0][1] == "https://example.com/image1.jpg"
-    assert results[1][0] == "prompt_2"
-    assert results[1][1] == "https://example.com/image2.jpg"
-
-    # No requests should be made during loading
-    assert mock_requests_get.call_count == 0
-    assert mock_pil_open.call_count == 0
+    with pytest.raises(ValueError, match="Streaming datasets are not supported"):
+        ImageDatasetLoader(dataset_config).load_request()


### PR DESCRIPTION
## Motivations

When trying to execute the benchmark below, the `ImageDatasetLoader` processes for a long time.

<img width="835" height="615" alt="Screenshot 2025-08-08 at 4 53 21 PM" src="https://github.com/user-attachments/assets/1400c413-96f6-48dd-b1e6-b9cd5b4a286b" />

The dataset config is:
```
{
    "source": {
        "type": "huggingface",
        "path": "zhang0jhon/Aesthetic-4K",
        "huggingface_kwargs": {
            "split": "train"
        }
    },
    "prompt_column": "text",
    "image_column": "image",
    "unsafe_allow_large_images": true
}
```

And without commit 7895404, it appears as the benchmark is stuck. This is because with a large dataset like `zhang0jhon/Aesthetic-4K`, (which has around 1.5k rows), the for loop in `ImageSampler._process_loaded_data` needs to take a O(n) time.

This PR tries to resolve this by moving the image and prompt extraction logic into `ImageSampler`.

## Modifications

- Image loader: stop eager iteration; return `datasets.Dataset` as-is; for
  `DatasetDict` auto-select a split (prefer 'train', else first) and warn;
  raise on streaming (`IterableDataset*`) instructing to disable streaming.
- Sampler: accept and store `dataset_config` in base; `ImageSampler` now
  lazily samples rows with `random.choices` and extracts prompt/image using
  config (no pre-materialization).
- Utils: add `safe_eval_prompt` and use it from `ImageSampler` for
  `prompt_lambda`.
- CLI: pass `dataset_config` when constructing the sampler.

This eliminates startup stalls from full-dataset iteration and supports
random-access sampling on HF datasets.