### PR TITLE
[Report] Add option for milliseconds

### DIFF
--- a/docs/user-guide/generate-plot.md
+++ b/docs/user-guide/generate-plot.md
@@ -236,6 +236,10 @@ A simplified 2x2 layout with the most important metrics for quick analysis.
 4. Use `--validate-only` to test your configuration
 5. Generate plots with your custom config
 
+### Time Units
+
+Pick the unit of time to measure latency fields with `--time-unit [s|ms]`. Plots default to using seconds if not specified.
+
 ### Tips
 
 - Use descriptive titles for your plots

--- a/docs/user-guide/run-benchmark.md
+++ b/docs/user-guide/run-benchmark.md
@@ -342,3 +342,7 @@ If you want to benchmark a specific portion of a vision dataset, you can use the
 - Reusable and version-controllable
 - Support for complex configurations
 - Future-proof (no CLI updates needed for new HuggingFace features)
+
+## Picking units
+
+Genai-bench defaults to measuring latency (End-to-end latency, TTFT, TPOT, Input/Output latencies) in seconds. If you prefer milliseconds, you can select them with `--time-unit [s|ms]`. 

--- a/examples/plot_configs/custom_2x2.json
+++ b/examples/plot_configs/custom_2x2.json
@@ -10,7 +10,7 @@
       "x_field": "mean_output_throughput_tokens_per_s",
       "y_field": "stats.e2e_latency.mean",
       "x_label": "Output Throughput (tokens/s)",
-      "y_label": "Mean E2E Latency (s)",
+      "y_label": "Mean E2E Latency (ms)",
       "plot_type": "line",
       "position": [0, 0]
     },

--- a/examples/plot_configs/custom_2x2.json
+++ b/examples/plot_configs/custom_2x2.json
@@ -10,7 +10,7 @@
       "x_field": "mean_output_throughput_tokens_per_s",
       "y_field": "stats.e2e_latency.mean",
       "x_label": "Output Throughput (tokens/s)",
-      "y_label": "Mean E2E Latency (ms)",
+      "y_label": "Mean E2E Latency (s)",
       "plot_type": "line",
       "position": [0, 0]
     },

--- a/genai_bench/analysis/flexible_plot_report.py
+++ b/genai_bench/analysis/flexible_plot_report.py
@@ -758,33 +758,23 @@ class FlexiblePlotGenerator:
 
     def _generate_label(self, field_path: str, time_unit: str = "s") -> str:
         """Generate a human-readable label from field path."""
-        # Simple label generation - can be enhanced
         parts = field_path.split(".")
-        if len(parts) == 1:
-            base_label = field_path.replace("_", " ").title()
-            # Apply time unit conversion if this is a latency field
-            if TimeUnitConverter.is_latency_field(field_path):
-                base_label = TimeUnitConverter.get_unit_label(base_label, time_unit)
-            return base_label
+        metric_name_for_latency_check = field_path
 
-        # Handle stats fields
         if parts[0] == "stats":
             metric = parts[1].replace("_", " ").title()
+            metric_name_for_latency_check = parts[1]
             if len(parts) > 2:
                 stat = parts[2].upper()
                 base_label = f"{metric} ({stat})"
             else:
                 base_label = metric
+        else:
+            base_label = field_path.replace("_", " ").title()
 
-            # Apply time unit conversion if this is a latency field
-            if TimeUnitConverter.is_latency_field(parts[1]):
-                base_label = TimeUnitConverter.get_unit_label(base_label, time_unit)
-            return base_label
-
-        base_label = field_path.replace("_", " ").title()
-        # Apply time unit conversion if this is a latency field
-        if TimeUnitConverter.is_latency_field(field_path):
+        if TimeUnitConverter.is_latency_field(metric_name_for_latency_check):
             base_label = TimeUnitConverter.get_unit_label(base_label, time_unit)
+
         return base_label
 
     def _finalize_and_save_plots(

--- a/genai_bench/analysis/flexible_plot_report.py
+++ b/genai_bench/analysis/flexible_plot_report.py
@@ -18,6 +18,7 @@ from genai_bench.analysis.plot_report import (
 from genai_bench.logging import init_logger
 from genai_bench.protocol import ExperimentMetadata
 from genai_bench.utils import sanitize_string
+from genai_bench.time_units import TimeUnitConverter
 
 logger = init_logger(__name__)
 
@@ -65,13 +66,14 @@ class FlexiblePlotGenerator:
         for scenario in all_scenarios:
             concurrency_data = experiment_metrics[scenario]
             concurrency_levels = sorted(concurrency_data.keys())
+            time_unit = metadata.time_unit
 
             fig, axs = self._create_figure()
             fig.suptitle(f"Single Scenario Analysis: {scenario}", fontsize=14)
 
             # Single scenario = no grouping, perfect for multi-line plots
             # Pass empty label since we're not grouping
-            self._plot_metrics(axs, [concurrency_data], {"": concurrency_levels}, [""])
+            self._plot_metrics(axs, [concurrency_data], {"": concurrency_levels}, [""], time_unit)
             self._finalize_and_save_plots(
                 axs,
                 fig,
@@ -90,10 +92,13 @@ class FlexiblePlotGenerator:
             run_data_list
         )
 
+        # Get time unit from the first experiment metadata
+        time_unit = run_data_list[0][0].time_unit if run_data_list else "s"
+
         fig, axs = self._create_figure()
         fig.suptitle("Grouped by Traffic Scenario", fontsize=14)
 
-        self._plot_metrics(axs, concurrency_data_list, label_to_concurrency_map, labels)
+        self._plot_metrics(axs, concurrency_data_list, label_to_concurrency_map, labels, time_unit)
         self._finalize_and_save_plots(
             axs, fig, labels, experiment_folder, "traffic_scenario"
         )
@@ -110,6 +115,9 @@ class FlexiblePlotGenerator:
             get_group_data,
         )
 
+        # Get time unit from the first experiment metadata
+        time_unit = run_data_list[0][0].time_unit if run_data_list else "s"
+
         traffic_scenarios = extract_traffic_scenarios(run_data_list)
         for traffic_scenario in traffic_scenarios:
             fig, axs = self._create_figure()
@@ -120,7 +128,7 @@ class FlexiblePlotGenerator:
             )
 
             self._plot_metrics(
-                axs, concurrency_data_list, label_to_concurrency_map, labels
+                axs, concurrency_data_list, label_to_concurrency_map, labels, time_unit
             )
             self._finalize_and_save_plots(
                 axs,
@@ -153,6 +161,7 @@ class FlexiblePlotGenerator:
         concurrency_data_list: List[Dict[int, MetricsData]],
         label_to_concurrency_map: Dict[str, List[int]],
         labels: List[str],
+        time_unit: str = "s",
     ) -> None:
         """Plot metrics based on configuration."""
         # Check if we have multi-line plots with multiple scenarios/groups
@@ -167,7 +176,7 @@ class FlexiblePlotGenerator:
             )
             # Convert multi-line plots to single-line plots automatically
             self._plot_metrics_single_line_fallback(
-                axs, concurrency_data_list, label_to_concurrency_map, labels
+                axs, concurrency_data_list, label_to_concurrency_map, labels, time_unit
             )
             return
 
@@ -181,6 +190,7 @@ class FlexiblePlotGenerator:
                     concurrency_data=concurrency_data,
                     concurrency_levels=concurrency_levels,
                     label=labels[i],
+                    time_unit=time_unit,
                 )
 
     def _plot_metrics_single_line_fallback(
@@ -189,6 +199,7 @@ class FlexiblePlotGenerator:
         concurrency_data_list: List[Dict[int, MetricsData]],
         label_to_concurrency_map: Dict[str, List[int]],
         labels: List[str],
+        time_unit: str = "s",
     ) -> None:
         """Fallback to single-line plotting when multi-line conflicts with grouping."""
         logger.info(
@@ -210,7 +221,7 @@ class FlexiblePlotGenerator:
 
                     single_line_spec = PlotSpec(
                         title=f"{plot_spec.title} "
-                        f"({first_field.label or self._generate_label(first_field.field)})",  # noqa: E501
+                        f"({first_field.label or self._generate_label(first_field.field, time_unit)})",  # noqa: E501
                         x_field=plot_spec.x_field,
                         y_field=first_field.field,
                         x_label=plot_spec.x_label,
@@ -227,6 +238,7 @@ class FlexiblePlotGenerator:
                         concurrency_data=concurrency_data,
                         concurrency_levels=concurrency_levels,
                         label=labels[i],
+                        time_unit=time_unit,
                     )
                 else:
                     # Regular single-line plot
@@ -236,6 +248,7 @@ class FlexiblePlotGenerator:
                         concurrency_data=concurrency_data,
                         concurrency_levels=concurrency_levels,
                         label=labels[i],
+                        time_unit=time_unit,
                     )
 
     def _plot_single_metric(
@@ -245,16 +258,17 @@ class FlexiblePlotGenerator:
         concurrency_data: Dict[int, MetricsData],
         concurrency_levels: List[int],
         label: str,
+        time_unit: str = "s",
     ) -> None:
         """Plot a single metric based on plot specification."""
         try:
             if plot_spec.is_multi_line():
                 self._plot_multi_line_metric(
-                    plot_spec, ax, concurrency_data, concurrency_levels, label
+                    plot_spec, ax, concurrency_data, concurrency_levels, label, time_unit
                 )
             else:
                 self._plot_single_line_metric(
-                    plot_spec, ax, concurrency_data, concurrency_levels, label
+                    plot_spec, ax, concurrency_data, concurrency_levels, label, time_unit
                 )
 
         except Exception as e:
@@ -275,6 +289,7 @@ class FlexiblePlotGenerator:
         concurrency_data: Dict[int, MetricsData],
         concurrency_levels: List[int],
         label: str,
+        time_unit: str = "s",
     ) -> None:
         """Plot a single line metric (original behavior)."""
         # Extract data using field paths
@@ -311,17 +326,27 @@ class FlexiblePlotGenerator:
         if y_field_spec.field == "error_rate" and plot_spec.plot_type == "bar":
             plot_error_rates(ax, concurrency_data, concurrency_levels, label)
         else:
+            # Apply time unit conversion to labels and title if this is a latency field
+            y_label = plot_spec.y_label or self._generate_label(y_field_spec.field, time_unit)
+            title = plot_spec.title
+            
+            # Convert labels to correct time unit if this is a latency field
+            if TimeUnitConverter.is_latency_field(y_field_spec.field):
+                y_label = TimeUnitConverter.get_unit_label(y_label, time_unit)
+                title = TimeUnitConverter.get_unit_label(title, time_unit)
+            
             # Use existing plot_graph function
             plot_graph(
                 ax=ax,
                 x_data=x_data,
                 y_data=y_data,
-                x_label=plot_spec.x_label or self._generate_label(plot_spec.x_field),
-                y_label=plot_spec.y_label or self._generate_label(y_field_spec.field),
-                title=plot_spec.title,
+                x_label=plot_spec.x_label or self._generate_label(plot_spec.x_field, time_unit),
+                y_label=y_label,
+                title=title,
                 concurrency_levels=valid_concurrency,
                 label=label,
                 plot_type=plot_spec.plot_type,
+                time_unit=time_unit,
             )
 
     def _add_plot_annotations(
@@ -331,6 +356,7 @@ class FlexiblePlotGenerator:
         valid_x: List[float],
         y_data: List[float],
         valid_concurrency: List[int],
+        time_unit: str = "s",
     ) -> None:
         """Add annotations to plot points."""
         for x_val, y_val, c_val in zip(
@@ -338,7 +364,11 @@ class FlexiblePlotGenerator:
         ):
             # Show y-value when x-axis is concurrency, otherwise show concurrency
             if plot_spec.x_field == "num_concurrency":
-                annotation_text = f"{y_val:.2f}"
+                # Format y-value with appropriate precision based on time unit
+                if time_unit == "ms":
+                    annotation_text = f"{y_val:.1f}"
+                else:
+                    annotation_text = f"{y_val:.2f}"
             else:
                 annotation_text = f"{c_val}"
 
@@ -365,6 +395,7 @@ class FlexiblePlotGenerator:
         concurrency_data: Dict[int, MetricsData],
         concurrency_levels: List[int],
         label: str,
+        time_unit: str = "s",
     ) -> None:
         """Plot multiple lines on the same subplot."""
         # Get colors from tab10 colormap
@@ -408,6 +439,10 @@ class FlexiblePlotGenerator:
                     )  # type: ignore[arg-type]
 
                     if y_val is not None:
+                        # Convert time values if this is a latency field
+                        if TimeUnitConverter.is_latency_field(y_field_spec.field):
+                            y_val = TimeUnitConverter.convert_value(y_val, "s", time_unit)
+                        
                         y_data.append(y_val)
                         # Use evenly spaced positions for concurrency, actual values
                         # otherwise
@@ -431,7 +466,7 @@ class FlexiblePlotGenerator:
             # Determine line styling
             color = y_field_spec.color or colors[i % len(colors)]
             linestyle = y_field_spec.linestyle or linestyles[i % len(linestyles)]
-            line_label = y_field_spec.label or self._generate_label(y_field_spec.field)
+            line_label = y_field_spec.label or self._generate_label(y_field_spec.field, time_unit)
 
             # For multi-line plots, keep labels clean
             full_label = line_label
@@ -453,6 +488,7 @@ class FlexiblePlotGenerator:
                     valid_x,
                     y_data,
                     valid_concurrency,
+                    time_unit,
                 )
             elif plot_spec.plot_type == "scatter":
                 ax.scatter(valid_x, y_data, color=color, label=full_label)
@@ -462,6 +498,7 @@ class FlexiblePlotGenerator:
                     valid_x,
                     y_data,
                     valid_concurrency,
+                    time_unit,
                 )
             elif plot_spec.plot_type == "bar":
                 # For bar plots with multiple fields, use grouped bars
@@ -478,9 +515,24 @@ class FlexiblePlotGenerator:
                 )
 
         # Set labels and title
-        ax.set_xlabel(plot_spec.x_label or self._generate_label(plot_spec.x_field))
-        ax.set_ylabel(plot_spec.y_label or "Value")
-        ax.set_title(plot_spec.title)
+        ax.set_xlabel(plot_spec.x_label or self._generate_label(plot_spec.x_field, time_unit))
+        
+        # Update y-axis label and title with correct time unit if this is a latency plot
+        y_label = plot_spec.y_label or "Value"
+        title = plot_spec.title
+        
+        # Check if any of the y-fields are latency fields to determine if we need time unit conversion
+        has_latency_fields = any(
+            TimeUnitConverter.is_latency_field(spec.field) 
+            for spec in plot_spec.get_y_field_specs()
+        )
+        
+        if has_latency_fields:
+            y_label = TimeUnitConverter.get_unit_label(y_label, time_unit)
+            title = TimeUnitConverter.get_unit_label(title, time_unit)
+        
+        ax.set_ylabel(y_label)
+        ax.set_title(title)
         ax.grid(True, alpha=0.3)
 
         # Position legend outside plot area for multi-line plots to avoid overlap
@@ -628,22 +680,36 @@ class FlexiblePlotGenerator:
             plt.close(fig_temp)
             logger.info(f"🎨 Saving {output_file}")
 
-    def _generate_label(self, field_path: str) -> str:
+    def _generate_label(self, field_path: str, time_unit: str = "s") -> str:
         """Generate a human-readable label from field path."""
         # Simple label generation - can be enhanced
         parts = field_path.split(".")
         if len(parts) == 1:
-            return field_path.replace("_", " ").title()
+            base_label = field_path.replace("_", " ").title()
+            # Apply time unit conversion if this is a latency field
+            if TimeUnitConverter.is_latency_field(field_path):
+                base_label = TimeUnitConverter.get_unit_label(base_label, time_unit)
+            return base_label
 
         # Handle stats fields
         if parts[0] == "stats":
             metric = parts[1].replace("_", " ").title()
             if len(parts) > 2:
                 stat = parts[2].upper()
-                return f"{metric} ({stat})"
-            return metric
+                base_label = f"{metric} ({stat})"
+            else:
+                base_label = metric
+            
+            # Apply time unit conversion if this is a latency field
+            if TimeUnitConverter.is_latency_field(parts[1]):
+                base_label = TimeUnitConverter.get_unit_label(base_label, time_unit)
+            return base_label
 
-        return field_path.replace("_", " ").title()
+        base_label = field_path.replace("_", " ").title()
+        # Apply time unit conversion if this is a latency field
+        if TimeUnitConverter.is_latency_field(field_path):
+            base_label = TimeUnitConverter.get_unit_label(base_label, time_unit)
+        return base_label
 
     def _finalize_and_save_plots(
         self,
@@ -706,8 +772,11 @@ def plot_experiment_data_flexible(
         experiment_folder: Output folder path
         plot_config: Plot configuration (uses default if None)
     """
+    # Extract time unit from the first experiment metadata
+    time_unit = run_data_list[0][0].time_unit if run_data_list else "s"
+    
     if plot_config is None:
-        plot_config = PlotConfigManager.load_preset("2x4_default")
+        plot_config = PlotConfigManager.load_preset("2x4_default", time_unit)
 
     generator = FlexiblePlotGenerator(plot_config)
     generator.generate_plots(run_data_list, group_key, experiment_folder)

--- a/genai_bench/analysis/plot_config.py
+++ b/genai_bench/analysis/plot_config.py
@@ -273,7 +273,7 @@ class PlotConfigManager:
                         },
                     ],
                     "x_label": "Requests Per Second",
-                    "y_label": "Latency (seconds)",
+                    "y_label": "Latency (s)",
                     "plot_type": "line",
                     "position": [0, 0],
                 },

--- a/genai_bench/analysis/plot_config.py
+++ b/genai_bench/analysis/plot_config.py
@@ -402,51 +402,63 @@ class PlotConfigManager:
     }
 
     @classmethod
-    def apply_time_unit_conversion(cls, config_data: Dict[str, Any], time_unit: str = "s") -> Dict[str, Any]:
+    def apply_time_unit_conversion(
+        cls, config_data: Dict[str, Any], time_unit: str = "s"
+    ) -> Dict[str, Any]:
         """
         Apply time unit conversion to plot configuration labels.
-        
+
         Args:
             config_data: Plot configuration dictionary
             time_unit: Target time unit ('s' or 'ms')
-            
+
         Returns:
             Modified configuration with updated labels
         """
         if time_unit not in ["s", "ms"]:
             return config_data
-            
+
         # Create a copy to avoid modifying the original
         config_copy = config_data.copy()
-        
+
         # Convert labels in each plot specification
         for plot_copy in config_copy.get("plots", []):
             # Convert title
             if "title" in plot_copy:
                 original_title = plot_copy["title"]
-                plot_copy["title"] = TimeUnitConverter.get_unit_label(original_title, time_unit)
-            
+                plot_copy["title"] = TimeUnitConverter.get_unit_label(
+                    original_title, time_unit
+                )
+
             # Convert y_label
             if "y_label" in plot_copy:
                 original_y_label = plot_copy["y_label"]
-                plot_copy["y_label"] = TimeUnitConverter.get_unit_label(original_y_label, time_unit)
-            
+                plot_copy["y_label"] = TimeUnitConverter.get_unit_label(
+                    original_y_label, time_unit
+                )
+
             # Convert x_label
             if "x_label" in plot_copy:
                 original_x_label = plot_copy["x_label"]
-                plot_copy["x_label"] = TimeUnitConverter.get_unit_label(original_x_label, time_unit)
-            
+                plot_copy["x_label"] = TimeUnitConverter.get_unit_label(
+                    original_x_label, time_unit
+                )
+
             # Convert y_fields labels
             if "y_fields" in plot_copy:
                 for y_field in plot_copy["y_fields"]:
                     if "label" in y_field:
                         original_label = y_field["label"]
-                        y_field["label"] = TimeUnitConverter.get_unit_label(original_label, time_unit)
-        
+                        y_field["label"] = TimeUnitConverter.get_unit_label(
+                            original_label, time_unit
+                        )
+
         return config_copy
 
     @classmethod
-    def load_config(cls, config_source: Union[str, Dict, None] = None, time_unit: str = "s") -> PlotConfig:
+    def load_config(
+        cls, config_source: Union[str, Dict, None] = None, time_unit: str = "s"
+    ) -> PlotConfig:
         """Load plot configuration from various sources."""
         if config_source is None:
             # Use default 2x4 preset
@@ -471,8 +483,10 @@ class PlotConfigManager:
     def load_preset(cls, preset_name: str, time_unit: str = "s") -> PlotConfig:
         """Load a preset plot configuration."""
         if preset_name not in cls.PRESETS:
-            raise ValueError(f"Unknown preset: {preset_name}. Available: {list(cls.PRESETS.keys())}")
-        
+            raise ValueError(
+                f"Unknown preset: {preset_name}. Available: {list(cls.PRESETS.keys())}"
+            )
+
         preset_data = cls.PRESETS[preset_name]
         return cls.load_config(preset_data, time_unit)
 

--- a/genai_bench/analysis/plot_config.py
+++ b/genai_bench/analysis/plot_config.py
@@ -153,7 +153,7 @@ class PlotConfigManager:
                     "x_field": "mean_output_throughput_tokens_per_s",
                     "y_field": "stats.ttft.mean",
                     "x_label": "Output Throughput of Server (tokens/s)",
-                    "y_label": "TTFT",
+                    "y_label": "TTFT (s)",
                     "plot_type": "line",
                     "position": [0, 1],
                 },
@@ -190,7 +190,7 @@ class PlotConfigManager:
                     "x_field": "mean_total_tokens_throughput_tokens_per_s",
                     "y_field": "stats.ttft.mean",
                     "x_label": "Total Throughput (Input + Output) of Server (tokens/s)",
-                    "y_label": "TTFT",
+                    "y_label": "TTFT (s)",
                     "plot_type": "line",
                     "position": [1, 1],
                 },
@@ -284,12 +284,12 @@ class PlotConfigManager:
                     "y_fields": [
                         {
                             "field": "stats.ttft.mean",
-                            "label": "Mean TTFT",
+                            "label": "Mean TTFT (s)",
                             "color": "green",
                         },
                         {
                             "field": "stats.ttft.p95",
-                            "label": "P95 TTFT",
+                            "label": "P95 TTFT (s)",
                             "color": "purple",
                         },
                     ],
@@ -365,12 +365,12 @@ class PlotConfigManager:
                     "y_fields": [
                         {
                             "field": "stats.ttft.mean",
-                            "label": "Mean TTFT",
+                            "label": "Mean TTFT (s)",
                             "color": "green",
                         },
                         {
                             "field": "stats.ttft.p95",
-                            "label": "P95 TTFT",
+                            "label": "P95 TTFT (s)",
                             "color": "purple",
                         },
                     ],

--- a/genai_bench/analysis/plot_report.py
+++ b/genai_bench/analysis/plot_report.py
@@ -44,15 +44,6 @@ def plot_graph(
         label (str): Label for the legend.
         plot_type (str): Type of plot, either "line" or "scatter".
     """
-    # Convert time data and update labels if needed
-    is_time_data = any(kw in y_label.lower() for kw in TimeUnitConverter.LATENCY_FIELDS)
-    if is_time_data:
-        y_data = [
-            TimeUnitConverter.convert_value(val, "s", time_unit) for val in y_data
-        ]
-        y_label = TimeUnitConverter.get_unit_label(y_label, time_unit)
-        title = TimeUnitConverter.get_unit_label(title, time_unit)
-
     if x_label == "Concurrency":
         # Set x-axis for concurrency levels to have even spacing
         x_positions = range(len(concurrency_levels))

--- a/genai_bench/analysis/plot_report.py
+++ b/genai_bench/analysis/plot_report.py
@@ -12,7 +12,6 @@ from matplotlib.figure import Figure
 from genai_bench.analysis.experiment_loader import ExperimentMetrics, MetricsData
 from genai_bench.logging import init_logger
 from genai_bench.protocol import ExperimentMetadata
-from genai_bench.time_units import TimeUnitConverter
 from genai_bench.utils import sanitize_string
 
 logger = init_logger(__name__)

--- a/genai_bench/analysis/plot_report.py
+++ b/genai_bench/analysis/plot_report.py
@@ -77,7 +77,7 @@ def plot_graph(
             ),
         )
 
-    if y_label == "TTFT":
+    if "TTFT" in y_label:
         ax.set_yscale("log", base=10)
         ax.yaxis.set_major_locator(
             mticker.LogLocator(base=10.0, subs=[1.0], numticks=10)
@@ -573,6 +573,7 @@ def plot_single_scenario_inference_speed_vs_throughput(
     task: str,
     scenario_metrics: Dict[str, Any],
     iteration_type: str,
+    time_unit: str = "s",
 ) -> None:
     """
     Plots metrics for a single scenario immediately after it completes.
@@ -586,6 +587,7 @@ def plot_single_scenario_inference_speed_vs_throughput(
                 or batch
              iteration_type: List of concurrency levels/batch
         iteration_type: Type of iteration for the benchmark. E.g. concurrency levels.
+        time_unit (str): [s|ms] Time unit for latency metrics display and export.
     """
     # TODO: This logic should be de-coupled.
     if (
@@ -642,7 +644,7 @@ def plot_single_scenario_inference_speed_vs_throughput(
         concurrency_levels=valid_concurrency,
         label=f"Scenario: {scenario_label}",
         plot_type="line",
-        time_unit="s",
+        time_unit=time_unit,
     )
 
     ax.legend()

--- a/genai_bench/cli/cli.py
+++ b/genai_bench/cli/cli.py
@@ -515,6 +515,7 @@ def benchmark(
         ],
         group_key="traffic_scenario",
         experiment_folder=experiment_folder_abs_path,
+        time_unit=time_unit,
     )
     logger.info(
         f"📁 Please check {experiment_folder_abs_path} "

--- a/genai_bench/cli/cli.py
+++ b/genai_bench/cli/cli.py
@@ -139,6 +139,7 @@ def benchmark(
     github_token,
     github_owner,
     github_repo,
+    time_unit,
 ):
     """
     Run a benchmark based on user defined scenarios.
@@ -334,6 +335,7 @@ def benchmark(
         additional_request_params=additional_request_params,
         dataset_path=str(dataset_path),
         character_token_ratio=sonnet_character_token_ratio,
+        time_unit=time_unit,
     )
     experiment_metadata_file = Path(
         os.path.join(experiment_folder_abs_path, "experiment_metadata.json")
@@ -436,7 +438,8 @@ def benchmark(
                         f"debug_for_run_{sanitized_scenario_str}_{concurrency}.json"
                     )
                     aggregated_metrics_collector.save(
-                        os.path.join(experiment_folder_abs_path, debug_file_name)
+                        os.path.join(experiment_folder_abs_path, debug_file_name),
+                        time_unit,
                     )
                     raise ValueError(
                         f"{str(e)} Please check out "
@@ -445,7 +448,7 @@ def benchmark(
                     ) from e
 
                 dashboard.update_scatter_plot_panel(
-                    aggregated_metrics_collector.get_ui_scatter_plot_metrics()
+                    aggregated_metrics_collector.get_ui_scatter_plot_metrics(time_unit)
                 )
 
                 logger.info(
@@ -460,7 +463,7 @@ def benchmark(
                     f"{iteration}_time_{total_run_time}s.json"
                 )
                 aggregated_metrics_collector.save(
-                    os.path.join(experiment_folder_abs_path, run_name)
+                    os.path.join(experiment_folder_abs_path, run_name), time_unit
                 )
                 # Store metrics in memory for interim plot
                 scenario_metrics["data"][iteration] = {

--- a/genai_bench/cli/cli.py
+++ b/genai_bench/cli/cli.py
@@ -509,6 +509,7 @@ def benchmark(
             f"{Path(experiment_folder_abs_path).name}_summary.xlsx",
         ),
         percentile="mean",
+        time_unit=time_unit,
     )
     plot_experiment_data_flexible(
         [

--- a/genai_bench/cli/cli.py
+++ b/genai_bench/cli/cli.py
@@ -448,7 +448,8 @@ def benchmark(
                     ) from e
 
                 dashboard.update_scatter_plot_panel(
-                    aggregated_metrics_collector.get_ui_scatter_plot_metrics(time_unit)
+                    aggregated_metrics_collector.get_ui_scatter_plot_metrics(time_unit),
+                    time_unit,
                 )
 
                 logger.info(

--- a/genai_bench/cli/cli.py
+++ b/genai_bench/cli/cli.py
@@ -145,7 +145,7 @@ def benchmark(
     Run a benchmark based on user defined scenarios.
     """
     # Set up the dashboard and layout
-    dashboard = create_dashboard()
+    dashboard = create_dashboard(time_unit)
 
     # Initialize logging with the layout for the log panel
     logging_manager = LoggingManager("benchmark", dashboard.layout, dashboard.live)

--- a/genai_bench/cli/option_groups.py
+++ b/genai_bench/cli/option_groups.py
@@ -555,6 +555,13 @@ def experiment_options(func):
         "or a local path. IMPORTANT: it should match the tokenizer the model "
         "server uses.",
     )(func)
+    func = click.option(
+        "--time-unit",
+        type=click.Choice(["s", "ms"], case_sensitive=False),
+        default="s",
+        help="Time unit for latency metrics display and export. "
+        "Options: 's' (seconds), 'ms' (milliseconds). Default: s",
+    )(func)
     return func
 
 

--- a/genai_bench/cli/report.py
+++ b/genai_bench/cli/report.py
@@ -89,6 +89,13 @@ def excel(ctx, experiment_folder, excel_name, metric_percentile):
     help="Use a built-in plot preset. Overrides --plot-config if both are provided.",
 )
 @click.option(
+    "--time-unit",
+    type=click.Choice(["s", "ms"], case_sensitive=False),
+    default="s",
+    help="Time unit for latency metrics display and export. "
+    "Options: 's' (seconds), 'ms' (milliseconds). Default: s",
+)
+@click.option(
     "--list-fields",
     is_flag=True,
     help="List all available fields with actual data from the experiment folder and "
@@ -99,16 +106,23 @@ def excel(ctx, experiment_folder, excel_name, metric_percentile):
     is_flag=True,
     help="Only validate the plot configuration without generating plots.",
 )
+@click.option(
+    "--verbose",
+    is_flag=True,
+    help="Enable verbose logging for debugging.",
+)
 @click.pass_context
 def plot(
     ctx,
     experiments_folder,
-    filter_criteria,
     group_key,
+    filter_criteria,
     plot_config,
     preset,
+    time_unit,
     list_fields,
     validate_only,
+    verbose,
 ):
     """
     Plots the experiment(s) results based on filters and group.
@@ -204,13 +218,13 @@ def plot(
         from genai_bench.analysis.plot_config import PlotConfigManager
 
         if preset:
-            config = PlotConfigManager.load_preset(preset)
+            config = PlotConfigManager.load_preset(preset, time_unit)
             logger.info(f"Using preset configuration: {preset}")
         elif plot_config:
-            config = PlotConfigManager.load_from_file(plot_config)
+            config = PlotConfigManager.load_from_file(plot_config, time_unit)
             logger.info(f"Using configuration from: {plot_config}")
         else:
-            config = PlotConfigManager.load_preset("2x4_default")
+            config = PlotConfigManager.load_preset("2x4_default", time_unit)
             logger.info("Using default 2x4 configuration")
 
     except Exception as e:

--- a/genai_bench/cli/report.py
+++ b/genai_bench/cli/report.py
@@ -52,7 +52,9 @@ def excel(ctx, experiment_folder, excel_name, metric_percentile, time_unit):
     _ = init_logger("genai_bench.excel")
     excel_path = os.path.join(experiment_folder, excel_name + ".xlsx")
     experiment_metadata, run_data = load_one_experiment(experiment_folder)
-    create_workbook(experiment_metadata, run_data, excel_path, metric_percentile, time_unit)
+    create_workbook(
+        experiment_metadata, run_data, excel_path, metric_percentile, time_unit
+    )
 
 
 @click.command()

--- a/genai_bench/cli/report.py
+++ b/genai_bench/cli/report.py
@@ -276,6 +276,7 @@ def plot(
             group_key=group_key,
             experiment_folder=experiments_folder,
             plot_config=config,
+            time_unit=time_unit,
         )
         logger.info("Plot generation completed successfully")
     except Exception as e:

--- a/genai_bench/cli/report.py
+++ b/genai_bench/cli/report.py
@@ -218,13 +218,13 @@ def plot(
         from genai_bench.analysis.plot_config import PlotConfigManager
 
         if preset:
-            config = PlotConfigManager.load_preset(preset, time_unit)
+            config = PlotConfigManager.load_preset(preset)
             logger.info(f"Using preset configuration: {preset}")
         elif plot_config:
-            config = PlotConfigManager.load_from_file(plot_config, time_unit)
+            config = PlotConfigManager.load_from_file(plot_config)
             logger.info(f"Using configuration from: {plot_config}")
         else:
-            config = PlotConfigManager.load_preset("2x4_default", time_unit)
+            config = PlotConfigManager.load_preset("2x4_default")
             logger.info("Using default 2x4 configuration")
 
     except Exception as e:

--- a/genai_bench/cli/report.py
+++ b/genai_bench/cli/report.py
@@ -36,8 +36,15 @@ from genai_bench.utils import is_single_experiment_folder
     prompt=True,
     help="Name of the Excel file. The system will create a <excel-name>.xlsx.",
 )
+@click.option(
+    "--time-unit",
+    type=click.Choice(["s", "ms"], case_sensitive=False),
+    default="s",
+    help="Time unit for latency metrics in the spreadsheet. "
+    "Options: 's' (seconds), 'ms' (milliseconds). Default: s",
+)
 @click.pass_context
-def excel(ctx, experiment_folder, excel_name, metric_percentile):
+def excel(ctx, experiment_folder, excel_name, metric_percentile, time_unit):
     """
     Exports the experiment results to an Excel file.
     """
@@ -45,7 +52,7 @@ def excel(ctx, experiment_folder, excel_name, metric_percentile):
     _ = init_logger("genai_bench.excel")
     excel_path = os.path.join(experiment_folder, excel_name + ".xlsx")
     experiment_metadata, run_data = load_one_experiment(experiment_folder)
-    create_workbook(experiment_metadata, run_data, excel_path, metric_percentile)
+    create_workbook(experiment_metadata, run_data, excel_path, metric_percentile, time_unit)
 
 
 @click.command()

--- a/genai_bench/protocol.py
+++ b/genai_bench/protocol.py
@@ -210,6 +210,10 @@ class ExperimentMetadata(BaseModel):
         ...,
         description="The name of the folder to save the experiment results.",
     )
+    time_unit: str = Field(
+        default="s",
+        description="Time unit for latency metrics display and export (s or ms).",
+    )
     dataset_path: Optional[str] = None
     character_token_ratio: Optional[float] = Field(
         None,

--- a/genai_bench/time_units.py
+++ b/genai_bench/time_units.py
@@ -54,7 +54,7 @@ class TimeUnitConverter:
 
     @classmethod
     def convert_metrics_dict(
-        cls, metrics_dict: Dict[str, Any], to_unit: str
+        cls, metrics_dict: Dict[str, Any], to_unit: str, from_unit: str = "s"
     ) -> Dict[str, Any]:
         """
         Convert all time values in a metrics dictionary.
@@ -66,7 +66,7 @@ class TimeUnitConverter:
         Returns:
             New dictionary with converted time values
         """
-        if to_unit == "s":
+        if to_unit == from_unit:
             return metrics_dict  # No conversion needed
 
         converted = metrics_dict.copy()
@@ -74,7 +74,9 @@ class TimeUnitConverter:
         # Convert direct latency fields
         for field in cls.LATENCY_FIELDS:
             if field in converted and converted[field] is not None:
-                converted[field] = cls.convert_value(converted[field], "s", to_unit)
+                converted[field] = cls.convert_value(
+                    converted[field], from_unit, to_unit
+                )
 
         # Convert stats nested fields
         if "stats" in converted and isinstance(converted["stats"], dict):
@@ -87,7 +89,7 @@ class TimeUnitConverter:
                     for stat_key in cls.STATS_KEYS:
                         if stat_key in stats_obj:
                             stats_obj[stat_key] = cls.convert_value(
-                                stats_obj[stat_key], "s", to_unit
+                                stats_obj[stat_key], from_unit, to_unit
                             )
                     converted["stats"][field] = stats_obj
 
@@ -95,7 +97,7 @@ class TimeUnitConverter:
 
     @classmethod
     def convert_metrics_list(
-        cls, metrics_list: List[Dict[str, Any]], to_unit: str
+        cls, metrics_list: List[Dict[str, Any]], to_unit: str, from_unit: str = "s"
     ) -> List[Dict[str, Any]]:
         """
         Convert time values in a list of metrics dictionaries.
@@ -108,7 +110,7 @@ class TimeUnitConverter:
             New list with converted time values
         """
         return [
-            cls.convert_metrics_dict(metrics_dict, to_unit)
+            cls.convert_metrics_dict(metrics_dict, to_unit, from_unit)
             for metrics_dict in metrics_list
         ]
 

--- a/genai_bench/time_units.py
+++ b/genai_bench/time_units.py
@@ -1,5 +1,6 @@
 """Time unit conversion utilities for genai-bench metrics."""
 
+import re
 from typing import Any, Dict, List, Optional
 
 
@@ -127,23 +128,11 @@ class TimeUnitConverter:
             Updated label with correct unit notation
         """
         if unit == "ms":
-            # Replace various forms of seconds notation with milliseconds
-            label = base_label.replace(" (s)", " (ms)")
-            label = label.replace("(s)", "(ms)")
-            label = label.replace(" per Request (seconds)", " per Request (ms)")
-            label = label.replace(
-                " Latency per Request (s)", " Latency per Request (ms)"
-            )
-            return label
+            # Replace (s) or (seconds) with (ms)
+            return re.sub(r"\((s|seconds)\)", "(ms)", base_label)
         elif unit == "s":
-            # Replace various forms of milliseconds notation with seconds
-            label = base_label.replace(" (ms)", " (s)")
-            label = label.replace("(ms)", "(s)")
-            label = label.replace(" per Request (milliseconds)", " per Request (s)")
-            label = label.replace(
-                " Latency per Request (ms)", " Latency per Request (s)"
-            )
-            return label
+            # Replace (ms) or (milliseconds) with (s)
+            return re.sub(r"\((ms|milliseconds)\)", "(s)", base_label)
         return base_label
 
     @staticmethod

--- a/genai_bench/time_units.py
+++ b/genai_bench/time_units.py
@@ -169,7 +169,4 @@ class TimeUnitConverter:
     @classmethod
     def is_latency_field(cls, field_name: str) -> bool:
         """Check if a field name represents a latency metric."""
-        for latency_field in cls.LATENCY_FIELDS:
-            if latency_field in field_name:
-                return True
-        return False
+        return any(latency_field in field_name for latency_field in cls.LATENCY_FIELDS)

--- a/genai_bench/time_units.py
+++ b/genai_bench/time_units.py
@@ -168,4 +168,4 @@ class TimeUnitConverter:
         Returns:
             True if field contains time/latency data
         """
-        return field_name in cls.LATENCY_FIELDS
+        return any(latency_field in field_name for latency_field in cls.LATENCY_FIELDS)

--- a/genai_bench/time_units.py
+++ b/genai_bench/time_units.py
@@ -1,0 +1,171 @@
+"""Time unit conversion utilities for genai-bench metrics."""
+
+from typing import Any, Dict, List, Optional
+
+
+class TimeUnitConverter:
+    """Utility class for converting time metrics between different units."""
+
+    # Fields that contain time/latency values (in seconds internally)
+    LATENCY_FIELDS = {"ttft", "tpot", "e2e_latency", "output_latency"}
+
+    # Stats fields that contain time statistics
+    STATS_KEYS = {
+        "min",
+        "max",
+        "mean",
+        "stddev",
+        "sum",
+        "p25",
+        "p50",
+        "p75",
+        "p90",
+        "p95",
+        "p99",
+    }
+
+    @staticmethod
+    def convert_value(
+        value: Optional[float], from_unit: str, to_unit: str
+    ) -> Optional[float]:
+        """
+        Convert a time value between units.
+
+        Args:
+            value: The time value to convert (can be None)
+            from_unit: Source unit ('s' or 'ms')
+            to_unit: Target unit ('s' or 'ms')
+
+        Returns:
+            Converted value or None if input was None
+        """
+        if value is None:
+            return None
+
+        if from_unit == to_unit:
+            return value
+
+        if from_unit == "s" and to_unit == "ms":
+            return value * 1000
+        elif from_unit == "ms" and to_unit == "s":
+            return value / 1000
+        else:
+            raise ValueError(f"Unsupported unit conversion: {from_unit} -> {to_unit}")
+
+    @classmethod
+    def convert_metrics_dict(
+        cls, metrics_dict: Dict[str, Any], to_unit: str
+    ) -> Dict[str, Any]:
+        """
+        Convert all time values in a metrics dictionary.
+
+        Args:
+            metrics_dict: Dictionary containing metrics data
+            to_unit: Target unit ('s' or 'ms')
+
+        Returns:
+            New dictionary with converted time values
+        """
+        if to_unit == "s":
+            return metrics_dict  # No conversion needed
+
+        converted = metrics_dict.copy()
+
+        # Convert direct latency fields
+        for field in cls.LATENCY_FIELDS:
+            if field in converted and converted[field] is not None:
+                converted[field] = cls.convert_value(converted[field], "s", to_unit)
+
+        # Convert stats nested fields
+        if "stats" in converted and isinstance(converted["stats"], dict):
+            converted["stats"] = converted["stats"].copy()
+            for field in cls.LATENCY_FIELDS:
+                if field in converted["stats"] and isinstance(
+                    converted["stats"][field], dict
+                ):
+                    stats_obj = converted["stats"][field].copy()
+                    for stat_key in cls.STATS_KEYS:
+                        if stat_key in stats_obj:
+                            stats_obj[stat_key] = cls.convert_value(
+                                stats_obj[stat_key], "s", to_unit
+                            )
+                    converted["stats"][field] = stats_obj
+
+        return converted
+
+    @classmethod
+    def convert_metrics_list(
+        cls, metrics_list: List[Dict[str, Any]], to_unit: str
+    ) -> List[Dict[str, Any]]:
+        """
+        Convert time values in a list of metrics dictionaries.
+
+        Args:
+            metrics_list: List of dictionaries containing metrics data
+            to_unit: Target unit ('s' or 'ms')
+
+        Returns:
+            New list with converted time values
+        """
+        return [
+            cls.convert_metrics_dict(metrics_dict, to_unit)
+            for metrics_dict in metrics_list
+        ]
+
+    @staticmethod
+    def get_unit_label(base_label: str, unit: str) -> str:
+        """
+        Update a label with the appropriate time unit.
+
+        Args:
+            base_label: Original label (may contain '(s)' or similar)
+            unit: Target unit ('s' or 'ms')
+
+        Returns:
+            Updated label with correct unit notation
+        """
+        if unit == "ms":
+            # Replace various forms of seconds notation with milliseconds
+            label = base_label.replace(" (s)", " (ms)")
+            label = label.replace("(s)", "(ms)")
+            label = label.replace(" per Request (seconds)", " per Request (ms)")
+            label = label.replace(
+                " Latency per Request (s)", " Latency per Request (ms)"
+            )
+            return label
+        return base_label
+
+    @staticmethod
+    def validate_unit(unit: str) -> str:
+        """
+        Validate and normalize a time unit string.
+
+        Args:
+            unit: Time unit string
+
+        Returns:
+            Normalized unit string
+
+        Raises:
+            ValueError: If unit is not supported
+        """
+        unit = unit.lower().strip()
+        if unit in ["s", "sec", "second", "seconds"]:
+            return "s"
+        elif unit in ["ms", "millisecond", "milliseconds"]:
+            return "ms"
+        else:
+            raise ValueError(f"Unsupported time unit: {unit}. Supported units: s, ms")
+
+    @classmethod
+    def is_latency_field(cls, field_name: str) -> bool:
+        """
+        Check if a field name represents a latency/time metric.
+
+        Args:
+            field_name: Name of the field
+
+        Returns:
+            True if field contains time/latency data
+        """
+        return field_name in cls.LATENCY_FIELDS

--- a/genai_bench/time_units.py
+++ b/genai_bench/time_units.py
@@ -118,7 +118,7 @@ class TimeUnitConverter:
         Update a label with the appropriate time unit.
 
         Args:
-            base_label: Original label (may contain '(s)' or similar)
+            base_label: Original label (may contain '(s)' or '(ms)' or similar)
             unit: Target unit ('s' or 'ms')
 
         Returns:
@@ -131,6 +131,15 @@ class TimeUnitConverter:
             label = label.replace(" per Request (seconds)", " per Request (ms)")
             label = label.replace(
                 " Latency per Request (s)", " Latency per Request (ms)"
+            )
+            return label
+        elif unit == "s":
+            # Replace various forms of milliseconds notation with seconds
+            label = base_label.replace(" (ms)", " (s)")
+            label = label.replace("(ms)", "(s)")
+            label = label.replace(" per Request (milliseconds)", " per Request (s)")
+            label = label.replace(
+                " Latency per Request (ms)", " Latency per Request (s)"
             )
             return label
         return base_label
@@ -159,13 +168,8 @@ class TimeUnitConverter:
 
     @classmethod
     def is_latency_field(cls, field_name: str) -> bool:
-        """
-        Check if a field name represents a latency/time metric.
-
-        Args:
-            field_name: Name of the field
-
-        Returns:
-            True if field contains time/latency data
-        """
-        return any(latency_field in field_name for latency_field in cls.LATENCY_FIELDS)
+        """Check if a field name represents a latency metric."""
+        for latency_field in cls.LATENCY_FIELDS:
+            if latency_field in field_name:
+                return True
+        return False

--- a/genai_bench/ui/dashboard.py
+++ b/genai_bench/ui/dashboard.py
@@ -48,7 +48,9 @@ class MinimalDashboard:
     ):
         pass
 
-    def update_histogram_panel(self, live_metrics: LiveMetricsData):
+    def update_histogram_panel(
+        self, live_metrics: LiveMetricsData, time_unit: str = "s"
+    ):
         pass
 
     def update_scatter_plot_panel(self, ui_scatter_plot_metrics: Optional[List[float]]):
@@ -194,13 +196,16 @@ class RichLiveDashboard:
         self.layout["output_throughput"].update(output_throughput_panel)
         self.layout["output_latency"].update(output_latency_panel)
 
-    def update_histogram_panel(self, live_metrics: LiveMetricsData):
+    def update_histogram_panel(
+        self, live_metrics: LiveMetricsData, time_unit: str = "s"
+    ):
         input_latency_hist_chart = create_horizontal_colored_bar_chart(
-            live_metrics["ttft"], bin_width=0.01
+            live_metrics["ttft"], bin_width=0.01, time_unit=time_unit
         )
         output_latency_hist_chart = create_horizontal_colored_bar_chart(
             live_metrics["output_latency"],
             bin_width=0.01,
+            time_unit=time_unit,
         )
 
         self.layout["input_histogram"].update(
@@ -320,7 +325,7 @@ class RichLiveDashboard:
             return
 
         self.update_metrics_panels(live_metrics, self.time_unit)
-        self.update_histogram_panel(live_metrics)
+        self.update_histogram_panel(live_metrics, self.time_unit)
 
     def reset_plot_metrics(self):
         """Reset plot metrics for each scenario."""

--- a/genai_bench/ui/dashboard.py
+++ b/genai_bench/ui/dashboard.py
@@ -212,7 +212,9 @@ class RichLiveDashboard:
             )
         )
 
-    def update_scatter_plot_panel(self, ui_scatter_plot_metrics: Optional[List[float]]):
+    def update_scatter_plot_panel(
+        self, ui_scatter_plot_metrics: Optional[List[float]], time_unit: str = "s"
+    ):
         if not ui_scatter_plot_metrics:
             logger.info("No ui_scatter_plot_metrics collected for this run.")
             return
@@ -228,13 +230,13 @@ class RichLiveDashboard:
         input_throughput_scatter_plot = create_scatter_plot(
             self.plot_metrics["input_throughput"],
             self.plot_metrics["ttft"],
-            y_unit="s",
+            y_unit=time_unit,
             x_unit="tokens/sec",
         )
         output_latency_scatter_plot = create_scatter_plot(
             self.plot_metrics["output_throughput"],
             self.plot_metrics["output_latency"],
-            y_unit="s",
+            y_unit=time_unit,
             x_unit="tokens/sec",
         )
 

--- a/genai_bench/ui/layout.py
+++ b/genai_bench/ui/layout.py
@@ -48,17 +48,29 @@ def create_layout():
     return layout
 
 
-def create_metric_panel(title, latency_data, throughput_data):
+def create_metric_panel(title, latency_data, throughput_data, time_unit: str = "s"):
+    # Convert latency values if needed
+    if time_unit == "ms":
+        # Convert seconds to milliseconds
+        latency_values = {
+            key: value * 1000 if value is not None else value
+            for key, value in latency_data.items()
+        }
+        time_unit_label = "ms"
+    else:
+        latency_values = latency_data
+        time_unit_label = "s"
+
     latency_table = Table.grid(expand=True)
     latency_table.add_column(justify="left")
     latency_table.add_row(
         Text.from_markup(
-            f"[yellow]Avg:[/yellow] {latency_data['mean']:.2f} s\n"
-            f"Min: {latency_data['min']:.2f} s\n"
-            f"Max: {latency_data['max']:.2f} s\n"
-            f"[blue]P50:[/blue] {latency_data['p50']:.2f} s\n"
-            f"[magenta]P90:[/magenta] {latency_data['p90']:.2f} s\n"
-            f"[green]P99:[/green] {latency_data['p99']:.2f} s",
+            f"[yellow]Avg:[/yellow] {latency_values['mean']:.2f} {time_unit_label}\n"
+            f"Min: {latency_values['min']:.2f} {time_unit_label}\n"
+            f"Max: {latency_values['max']:.2f} {time_unit_label}\n"
+            f"[blue]P50:[/blue] {latency_values['p50']:.2f} {time_unit_label}\n"
+            f"[magenta]P90:[/magenta] {latency_values['p90']:.2f} {time_unit_label}\n"
+            f"[green]P99:[/green] {latency_values['p99']:.2f} {time_unit_label}",
             justify="left",
         )
     )

--- a/genai_bench/ui/plots.py
+++ b/genai_bench/ui/plots.py
@@ -8,7 +8,9 @@ from genai_bench.logging import init_logger
 logger = init_logger(__name__)
 
 
-def create_horizontal_colored_bar_chart(values, width=40, bin_width=0.1, max_bins=10):
+def create_horizontal_colored_bar_chart(
+    values, width=40, bin_width=0.1, max_bins=10, time_unit="s"
+):
     if not values:
         logger.warning("No data for histogram.")
         return Text()
@@ -30,9 +32,17 @@ def create_horizontal_colored_bar_chart(values, width=40, bin_width=0.1, max_bin
     chart = Text()
 
     # Format the labels for the bins using integer or specified decimal width
-    bin_labels = [
-        f"{bin_edges[i]:.2f}-{bin_edges[i + 1]:.2f}" for i in range(len(bin_edges) - 1)
-    ]
+    # Convert bin edges if time_unit is "ms"
+    if time_unit == "ms":
+        bin_labels = [
+            f"{bin_edges[i] * 1000:.0f}-{bin_edges[i + 1] * 1000:.0f}ms"
+            for i in range(len(bin_edges) - 1)
+        ]
+    else:
+        bin_labels = [
+            f"{bin_edges[i]:.2f}-{bin_edges[i + 1]:.2f}s"
+            for i in range(len(bin_edges) - 1)
+        ]
 
     # Determine the width of the longest label
     max_label_width = max(len(label) for label in bin_labels)

--- a/genai_bench/ui/plots.py
+++ b/genai_bench/ui/plots.py
@@ -69,6 +69,10 @@ def create_scatter_plot(x_values, y_values, width=40, height=10, y_unit="", x_un
         logger.warning("No data for scatter plot.")
         return Text()
 
+    # Calculate spacing based on time unit
+    # 7 spaces for seconds, 9 spaces for milliseconds to accommodate longer labels
+    label_spacing = 9 if y_unit == "ms" else 7
+
     # Determine ranges
     x_min, x_max = min(x_values), max(x_values)
     y_min, y_max = min(y_values), max(y_values)
@@ -107,23 +111,24 @@ def create_scatter_plot(x_values, y_values, width=40, height=10, y_unit="", x_un
             )
             # Avoid printing the same label as the row above
             if y_label != last_y_label:
-                y_label_str = f"{y_label:<7}"
+                y_label_str = f"{y_label:<{label_spacing}}"
                 last_y_label = y_label
                 if i == 0:  # Add unit to the top row
                     y_label_str = (
-                        f"{y_label:<{6 - len(y_unit)}} {y_unit:<{len(y_unit)}}"
+                        f"{y_label:<{label_spacing - len(y_unit) - 1}} "
+                        f"{y_unit:<{len(y_unit)}}"
                     )
             else:
-                y_label_str = " " * 7  # Leave space for the label
+                y_label_str = " " * label_spacing  # Leave space for the label
         else:
-            y_label_str = " " * 7  # Leave space for the label
+            y_label_str = " " * label_spacing  # Leave space for the label
 
         # Construct the row with dots
         plot_line = "".join(plot[i]) if i < len(plot) else ""
         chart.append(Text(f"{y_label_str}|{plot_line}\n"))
 
     # Add x-axis line
-    x_axis_line = "       " + "-" * (width + 1) + "\n"
+    x_axis_line = " " * label_spacing + "-" * (width + 1) + "\n"
     chart.append(Text(x_axis_line))
 
     # Create x-axis labels using actual x_values
@@ -142,7 +147,9 @@ def create_scatter_plot(x_values, y_values, width=40, height=10, y_unit="", x_un
             last_x_pos = x_pos
 
     # Add unit to the rightmost position, on the same line
-    x_label_line = "       " + "".join(x_labels) + f"{x_unit:<{len(x_unit)}}\n"
+    x_label_line = (
+        " " * label_spacing + "".join(x_labels) + f"{x_unit:<{len(x_unit)}}\n"
+    )
     chart.append(Text(x_label_line))
 
     return chart

--- a/tests/analysis/test_excel_na.py
+++ b/tests/analysis/test_excel_na.py
@@ -40,11 +40,12 @@ def _agg_metrics(
     num_concurrency: int,
     output_infer_speed_mean: float,
     ttft_mean: float = 0.5,
+    e2e_latency_mean: float = 1.0,
 ) -> AggregatedMetrics:
     stats = MetricStats(
         output_inference_speed=StatField(mean=output_infer_speed_mean),
         ttft=StatField(mean=ttft_mean),
-        e2e_latency=StatField(mean=1.0),
+        e2e_latency=StatField(mean=e2e_latency_mean),
     )
     return AggregatedMetrics(
         scenario=scenario,
@@ -101,7 +102,11 @@ def test_time_unit_conversion_seconds_to_milliseconds():
         scenario: {
             1: {
                 "aggregated_metrics": _agg_metrics(
-                    scenario, 1, output_infer_speed_mean=15.0, ttft_mean=0.5
+                    scenario,
+                    1,
+                    output_infer_speed_mean=15.0,
+                    ttft_mean=0.5,
+                    e2e_latency_mean=1.0,
                 ),
                 "individual_request_metrics": [{}],
             }
@@ -147,6 +152,7 @@ def test_time_unit_conversion_milliseconds_to_seconds():
                     1,
                     output_infer_speed_mean=15.0,
                     ttft_mean=500.0,  # 500ms = 0.5s
+                    e2e_latency_mean=1000.0,  # 1000ms = 1.0s
                 ),
                 "individual_request_metrics": [{}],
             }
@@ -175,5 +181,5 @@ def test_time_unit_conversion_milliseconds_to_seconds():
         # Check that e2e_latency value was converted from 1000ms to 1.0s
         e2e_latency_value = ws[2][6].value  # Row 2, column 7 (e2e_latency value)
         assert (
-            e2e_latency_value == 0.001
-        ), f"Expected e2e_latency value 0.001s, got: {e2e_latency_value}"
+            e2e_latency_value == 1
+        ), f"Expected e2e_latency value 1s, got: {e2e_latency_value}"

--- a/tests/analysis/test_plot_config.py
+++ b/tests/analysis/test_plot_config.py
@@ -1,0 +1,129 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+from genai_bench.analysis.plot_config import PlotConfigManager
+from genai_bench.time_units import TimeUnitConverter
+
+
+def test_apply_time_unit_conversion_to_ms():
+    """Test that labels are correctly converted from (s) to (ms)."""
+    config_data = {
+        "plots": [
+            {
+                "title": "TTFT vs Throughput",
+                "y_label": "TTFT (s)",
+                "x_label": "Throughput (tokens/s)",
+                "y_fields": [
+                    {"field": "stats.ttft.mean", "label": "Mean TTFT (s)"},
+                    {"field": "stats.ttft.p95", "label": "P95 TTFT (s)"}
+                ]
+            }
+        ]
+    }
+    
+    converted = PlotConfigManager.apply_time_unit_conversion(config_data, "ms")
+    
+    # Check title conversion
+    assert converted["plots"][0]["title"] == "TTFT vs Throughput"
+    
+    # Check y_label conversion
+    assert converted["plots"][0]["y_label"] == "TTFT (ms)"
+    
+    # Check x_label (should not change as it's not a time field)
+    assert converted["plots"][0]["x_label"] == "Throughput (tokens/s)"
+    
+    # Check y_fields labels
+    assert converted["plots"][0]["y_fields"][0]["label"] == "Mean TTFT (ms)"
+    assert converted["plots"][0]["y_fields"][1]["label"] == "P95 TTFT (ms)"
+
+
+def test_apply_time_unit_conversion_to_seconds():
+    """Test that labels are correctly converted from (ms) to (s)."""
+    config_data = {
+        "plots": [
+            {
+                "title": "Latency Analysis",
+                "y_label": "E2E Latency (ms)",
+                "x_label": "Concurrency",
+                "y_fields": [
+                    {"field": "stats.e2e_latency.mean", "label": "Mean Latency (ms)"},
+                    {"field": "stats.e2e_latency.p99", "label": "P99 Latency (ms)"}
+                ]
+            }
+        ]
+    }
+    
+    converted = PlotConfigManager.apply_time_unit_conversion(config_data, "s")
+    
+    # Check y_label conversion
+    assert converted["plots"][0]["y_label"] == "E2E Latency (s)"
+    
+    # Check y_fields labels
+    assert converted["plots"][0]["y_fields"][0]["label"] == "Mean Latency (s)"
+    assert converted["plots"][0]["y_fields"][1]["label"] == "P99 Latency (s)"
+
+
+def test_apply_time_unit_conversion_no_change():
+    """Test that no conversion happens when target unit matches source unit."""
+    config_data = {
+        "plots": [
+            {
+                "title": "TTFT Analysis",
+                "y_label": "TTFT (s)",
+                "y_fields": [
+                    {"field": "stats.ttft.mean", "label": "Mean TTFT (s)"}
+                ]
+            }
+        ]
+    }
+    
+    # Convert to seconds (should be no-op)
+    converted = PlotConfigManager.apply_time_unit_conversion(config_data, "s")
+    
+    # Check that labels remain unchanged
+    assert converted["plots"][0]["y_label"] == "TTFT (s)"
+    assert converted["plots"][0]["y_fields"][0]["label"] == "Mean TTFT (s)"
+
+
+def test_apply_time_unit_conversion_invalid_unit():
+    """Test that invalid time units are handled gracefully."""
+    config_data = {
+        "plots": [
+            {
+                "title": "Test Plot",
+                "y_label": "TTFT (s)"
+            }
+        ]
+    }
+    
+    # Invalid time unit should return original config unchanged
+    converted = PlotConfigManager.apply_time_unit_conversion(config_data, "invalid")
+    
+    assert converted == config_data
+
+
+def test_apply_time_unit_conversion_empty_plots():
+    """Test that empty plots list is handled correctly."""
+    config_data = {"plots": []}
+    
+    converted = PlotConfigManager.apply_time_unit_conversion(config_data, "ms")
+    
+    assert converted == config_data
+
+
+def test_apply_time_unit_conversion_missing_fields():
+    """Test that missing fields are handled gracefully."""
+    config_data = {
+        "plots": [
+            {
+                "title": "Test Plot"
+                # Missing y_label and y_fields
+            }
+        ]
+    }
+    
+    converted = PlotConfigManager.apply_time_unit_conversion(config_data, "ms")
+    
+    # Should not crash and should return the config
+    assert "title" in converted["plots"][0]
+    assert converted["plots"][0]["title"] == "Test Plot"

--- a/tests/analysis/test_plot_config.py
+++ b/tests/analysis/test_plot_config.py
@@ -1,8 +1,4 @@
-import pytest
-from unittest.mock import patch, MagicMock
-
 from genai_bench.analysis.plot_config import PlotConfigManager
-from genai_bench.time_units import TimeUnitConverter
 
 
 def test_apply_time_unit_conversion_to_ms():
@@ -15,23 +11,23 @@ def test_apply_time_unit_conversion_to_ms():
                 "x_label": "Throughput (tokens/s)",
                 "y_fields": [
                     {"field": "stats.ttft.mean", "label": "Mean TTFT (s)"},
-                    {"field": "stats.ttft.p95", "label": "P95 TTFT (s)"}
-                ]
+                    {"field": "stats.ttft.p95", "label": "P95 TTFT (s)"},
+                ],
             }
         ]
     }
-    
+
     converted = PlotConfigManager.apply_time_unit_conversion(config_data, "ms")
-    
+
     # Check title conversion
     assert converted["plots"][0]["title"] == "TTFT vs Throughput"
-    
+
     # Check y_label conversion
     assert converted["plots"][0]["y_label"] == "TTFT (ms)"
-    
+
     # Check x_label (should not change as it's not a time field)
     assert converted["plots"][0]["x_label"] == "Throughput (tokens/s)"
-    
+
     # Check y_fields labels
     assert converted["plots"][0]["y_fields"][0]["label"] == "Mean TTFT (ms)"
     assert converted["plots"][0]["y_fields"][1]["label"] == "P95 TTFT (ms)"
@@ -47,17 +43,17 @@ def test_apply_time_unit_conversion_to_seconds():
                 "x_label": "Concurrency",
                 "y_fields": [
                     {"field": "stats.e2e_latency.mean", "label": "Mean Latency (ms)"},
-                    {"field": "stats.e2e_latency.p99", "label": "P99 Latency (ms)"}
-                ]
+                    {"field": "stats.e2e_latency.p99", "label": "P99 Latency (ms)"},
+                ],
             }
         ]
     }
-    
+
     converted = PlotConfigManager.apply_time_unit_conversion(config_data, "s")
-    
+
     # Check y_label conversion
     assert converted["plots"][0]["y_label"] == "E2E Latency (s)"
-    
+
     # Check y_fields labels
     assert converted["plots"][0]["y_fields"][0]["label"] == "Mean Latency (s)"
     assert converted["plots"][0]["y_fields"][1]["label"] == "P99 Latency (s)"
@@ -70,16 +66,14 @@ def test_apply_time_unit_conversion_no_change():
             {
                 "title": "TTFT Analysis",
                 "y_label": "TTFT (s)",
-                "y_fields": [
-                    {"field": "stats.ttft.mean", "label": "Mean TTFT (s)"}
-                ]
+                "y_fields": [{"field": "stats.ttft.mean", "label": "Mean TTFT (s)"}],
             }
         ]
     }
-    
+
     # Convert to seconds (should be no-op)
     converted = PlotConfigManager.apply_time_unit_conversion(config_data, "s")
-    
+
     # Check that labels remain unchanged
     assert converted["plots"][0]["y_label"] == "TTFT (s)"
     assert converted["plots"][0]["y_fields"][0]["label"] == "Mean TTFT (s)"
@@ -87,27 +81,20 @@ def test_apply_time_unit_conversion_no_change():
 
 def test_apply_time_unit_conversion_invalid_unit():
     """Test that invalid time units are handled gracefully."""
-    config_data = {
-        "plots": [
-            {
-                "title": "Test Plot",
-                "y_label": "TTFT (s)"
-            }
-        ]
-    }
-    
+    config_data = {"plots": [{"title": "Test Plot", "y_label": "TTFT (s)"}]}
+
     # Invalid time unit should return original config unchanged
     converted = PlotConfigManager.apply_time_unit_conversion(config_data, "invalid")
-    
+
     assert converted == config_data
 
 
 def test_apply_time_unit_conversion_empty_plots():
     """Test that empty plots list is handled correctly."""
     config_data = {"plots": []}
-    
+
     converted = PlotConfigManager.apply_time_unit_conversion(config_data, "ms")
-    
+
     assert converted == config_data
 
 
@@ -121,9 +108,9 @@ def test_apply_time_unit_conversion_missing_fields():
             }
         ]
     }
-    
+
     converted = PlotConfigManager.apply_time_unit_conversion(config_data, "ms")
-    
+
     # Should not crash and should return the config
     assert "title" in converted["plots"][0]
     assert converted["plots"][0]["title"] == "Test Plot"

--- a/tests/analysis/test_plot_report.py
+++ b/tests/analysis/test_plot_report.py
@@ -109,6 +109,7 @@ def test_plot_single_scenario_success(
         concurrency_levels=[1, 2],
         label="Scenario: test_scenario",
         plot_type="line",
+        time_unit="s",
     )
     assert mock_plt.savefig.called
     assert mock_plt.close.called
@@ -151,6 +152,7 @@ def test_plot_single_scenario_with_missing_data(
         concurrency_levels=[1, 2],
         label="Scenario: test_scenario",
         plot_type="line",
+        time_unit="s",
     )
 
     # Verify warnings were logged for missing data

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -1,0 +1,97 @@
+import pytest
+from unittest.mock import patch, Mock
+from click.testing import CliRunner
+
+from genai_bench.cli.report import plot
+
+
+@pytest.fixture
+def cli_runner():
+    """Create a CLI runner for testing."""
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_experiment_data():
+    """Create mock experiment data."""
+    metadata = Mock()
+    metadata.time_unit = "s"  # Source time unit from experiment
+    
+    run_data = {
+        "scenario1": {
+            1: {
+                "aggregated_metrics": Mock(
+                    stats=Mock(
+                        ttft=Mock(mean=0.1),
+                        e2e_latency=Mock(mean=0.5)
+                    ),
+                    mean_output_throughput_tokens_per_s=100.0
+                ),
+                "_time_unit": "s"
+            }
+        }
+    }
+    
+    return [(metadata, run_data)]
+
+def test_cli_time_unit_parameter_passed(cli_runner, mock_experiment_data):
+    """Test that the --time-unit CLI parameter is correctly passed through."""
+    with patch('genai_bench.cli.report.load_multiple_experiments', return_value=mock_experiment_data), \
+         patch('genai_bench.analysis.flexible_plot_report.plot_experiment_data_flexible') as mock_plot:
+        
+        result = cli_runner.invoke(plot, [
+            '--experiments-folder', '/tmp',
+            '--group-key', 'traffic_scenario',
+            '--time-unit', 'ms'
+        ])
+        
+        # Verify the plotting function was called with the correct time unit
+        call_args = mock_plot.call_args
+        assert call_args[1]['time_unit'] == 'ms'
+
+
+def test_cli_time_unit_default_value(cli_runner, mock_experiment_data):
+    """Test that the default time unit is 's' when not specified."""
+    with patch('genai_bench.cli.report.load_multiple_experiments', return_value=mock_experiment_data), \
+         patch('genai_bench.analysis.flexible_plot_report.plot_experiment_data_flexible') as mock_plot:
+        
+        result = cli_runner.invoke(plot, [
+            '--experiments-folder', '/tmp',
+            '--group-key', 'traffic_scenario'
+            # No --time-unit specified
+        ])
+        
+        # Verify the plotting function was called with default time unit
+        call_args = mock_plot.call_args
+        assert call_args[1]['time_unit'] == 's'
+
+
+def test_cli_time_unit_parameter_validation(cli_runner):
+    """Test that invalid time unit values are rejected."""
+    result = cli_runner.invoke(plot, [
+        '--experiments-folder', '/tmp',
+        '--group-key', 'traffic_scenario',
+        '--time-unit', 'invalid_unit'
+    ])
+    
+    # Should fail with invalid choice error
+    assert result.exit_code != 0
+    assert "Invalid value for '--time-unit'" in result.output
+
+
+def test_cli_time_unit_with_preset(cli_runner, mock_experiment_data):
+    """Test that time unit works correctly with preset configurations."""
+    with patch('genai_bench.cli.report.load_multiple_experiments', return_value=mock_experiment_data), \
+         patch('genai_bench.analysis.flexible_plot_report.plot_experiment_data_flexible') as mock_plot:
+        
+        result = cli_runner.invoke(plot, [
+            '--experiments-folder', '/tmp',
+            '--group-key', 'traffic_scenario',
+            '--preset', '2x4_default',
+            '--time-unit', 'ms'
+        ])
+        
+        # Verify the plotting function was called with correct parameters
+        mock_plot.assert_called_once()
+        call_args = mock_plot.call_args
+        assert call_args[1]['time_unit'] == 'ms'

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -1,5 +1,6 @@
+from unittest.mock import Mock, patch
+
 import pytest
-from unittest.mock import patch, Mock
 from click.testing import CliRunner
 
 from genai_bench.cli.report import plot
@@ -16,64 +17,91 @@ def mock_experiment_data():
     """Create mock experiment data."""
     metadata = Mock()
     metadata.time_unit = "s"  # Source time unit from experiment
-    
+
     run_data = {
         "scenario1": {
             1: {
                 "aggregated_metrics": Mock(
-                    stats=Mock(
-                        ttft=Mock(mean=0.1),
-                        e2e_latency=Mock(mean=0.5)
-                    ),
-                    mean_output_throughput_tokens_per_s=100.0
+                    stats=Mock(ttft=Mock(mean=0.1), e2e_latency=Mock(mean=0.5)),
+                    mean_output_throughput_tokens_per_s=100.0,
                 ),
-                "_time_unit": "s"
+                "_time_unit": "s",
             }
         }
     }
-    
+
     return [(metadata, run_data)]
+
 
 def test_cli_time_unit_parameter_passed(cli_runner, mock_experiment_data):
     """Test that the --time-unit CLI parameter is correctly passed through."""
-    with patch('genai_bench.cli.report.load_multiple_experiments', return_value=mock_experiment_data), \
-         patch('genai_bench.analysis.flexible_plot_report.plot_experiment_data_flexible') as mock_plot:
-        
-        result = cli_runner.invoke(plot, [
-            '--experiments-folder', '/tmp',
-            '--group-key', 'traffic_scenario',
-            '--time-unit', 'ms'
-        ])
-        
+    with (
+        patch(
+            "genai_bench.cli.report.load_multiple_experiments",
+            return_value=mock_experiment_data,
+        ),
+        patch(
+            "genai_bench.analysis.flexible_plot_report.plot_experiment_data_flexible"
+        ) as mock_plot,
+    ):
+        cli_runner.invoke(
+            plot,
+            [
+                "--experiments-folder",
+                "/tmp",
+                "--group-key",
+                "traffic_scenario",
+                "--time-unit",
+                "ms",
+            ],
+        )
+
         # Verify the plotting function was called with the correct time unit
         call_args = mock_plot.call_args
-        assert call_args[1]['time_unit'] == 'ms'
+        assert call_args[1]["time_unit"] == "ms"
 
 
 def test_cli_time_unit_default_value(cli_runner, mock_experiment_data):
     """Test that the default time unit is 's' when not specified."""
-    with patch('genai_bench.cli.report.load_multiple_experiments', return_value=mock_experiment_data), \
-         patch('genai_bench.analysis.flexible_plot_report.plot_experiment_data_flexible') as mock_plot:
-        
-        result = cli_runner.invoke(plot, [
-            '--experiments-folder', '/tmp',
-            '--group-key', 'traffic_scenario'
-            # No --time-unit specified
-        ])
-        
+    with (
+        patch(
+            "genai_bench.cli.report.load_multiple_experiments",
+            return_value=mock_experiment_data,
+        ),
+        patch(
+            "genai_bench.analysis.flexible_plot_report.plot_experiment_data_flexible"
+        ) as mock_plot,
+    ):
+        cli_runner.invoke(
+            plot,
+            [
+                "--experiments-folder",
+                "/tmp",
+                "--group-key",
+                "traffic_scenario",
+                # No --time-unit specified
+            ],
+        )
+
         # Verify the plotting function was called with default time unit
         call_args = mock_plot.call_args
-        assert call_args[1]['time_unit'] == 's'
+        assert call_args[1]["time_unit"] == "s"
 
 
 def test_cli_time_unit_parameter_validation(cli_runner):
     """Test that invalid time unit values are rejected."""
-    result = cli_runner.invoke(plot, [
-        '--experiments-folder', '/tmp',
-        '--group-key', 'traffic_scenario',
-        '--time-unit', 'invalid_unit'
-    ])
-    
+    result = cli_runner.invoke(
+        plot,
+        [
+            "--experiments-folder",
+            "/tmp",
+            "--group-key",
+            "traffic_scenario",
+            "--time-unit",
+            "invalid_unit",
+        ],
+    )
+
     # Should fail with invalid choice error
     assert result.exit_code != 0
     assert "Invalid value for '--time-unit'" in result.output
@@ -81,17 +109,30 @@ def test_cli_time_unit_parameter_validation(cli_runner):
 
 def test_cli_time_unit_with_preset(cli_runner, mock_experiment_data):
     """Test that time unit works correctly with preset configurations."""
-    with patch('genai_bench.cli.report.load_multiple_experiments', return_value=mock_experiment_data), \
-         patch('genai_bench.analysis.flexible_plot_report.plot_experiment_data_flexible') as mock_plot:
-        
-        result = cli_runner.invoke(plot, [
-            '--experiments-folder', '/tmp',
-            '--group-key', 'traffic_scenario',
-            '--preset', '2x4_default',
-            '--time-unit', 'ms'
-        ])
-        
+    with (
+        patch(
+            "genai_bench.cli.report.load_multiple_experiments",
+            return_value=mock_experiment_data,
+        ),
+        patch(
+            "genai_bench.analysis.flexible_plot_report.plot_experiment_data_flexible"
+        ) as mock_plot,
+    ):
+        cli_runner.invoke(
+            plot,
+            [
+                "--experiments-folder",
+                "/tmp",
+                "--group-key",
+                "traffic_scenario",
+                "--preset",
+                "2x4_default",
+                "--time-unit",
+                "ms",
+            ],
+        )
+
         # Verify the plotting function was called with correct parameters
         mock_plot.assert_called_once()
         call_args = mock_plot.call_args
-        assert call_args[1]['time_unit'] == 'ms'
+        assert call_args[1]["time_unit"] == "ms"

--- a/tests/test_time_units.py
+++ b/tests/test_time_units.py
@@ -46,8 +46,14 @@ class TestTimeUnitConverter:
             TimeUnitConverter.get_unit_label("End-to-End Latency per Request (s)", "ms")
             == "End-to-End Latency per Request (ms)"
         )
+        assert TimeUnitConverter.get_unit_label("TTFT (ms)", "s") == "TTFT (s)"
+        assert TimeUnitConverter.get_unit_label("TTFT", "s") == "TTFT"
+        assert (
+            TimeUnitConverter.get_unit_label("End-to-End Latency per Request (ms)", "s")
+            == "End-to-End Latency per Request (s)"
+        )
 
-        # No change for seconds
+        # No change for same unit
         assert TimeUnitConverter.get_unit_label("TTFT (s)", "s") == "TTFT (s)"
 
     def test_metrics_dict_conversion(self):

--- a/tests/test_time_units.py
+++ b/tests/test_time_units.py
@@ -1,0 +1,135 @@
+"""Tests for time unit conversion functionality."""
+
+import pytest
+
+from genai_bench.time_units import TimeUnitConverter
+
+
+class TestTimeUnitConverter:
+    """Test TimeUnitConverter utility class."""
+
+    def test_basic_conversion(self):
+        """Test basic time unit conversions."""
+        # Seconds to milliseconds
+        assert TimeUnitConverter.convert_value(1.0, "s", "ms") == 1000.0
+        assert TimeUnitConverter.convert_value(1.5, "s", "ms") == 1500.0
+        assert TimeUnitConverter.convert_value(0.001, "s", "ms") == 1.0
+
+        # Milliseconds to seconds
+        assert TimeUnitConverter.convert_value(1000.0, "ms", "s") == 1.0
+        assert TimeUnitConverter.convert_value(1500.0, "ms", "s") == 1.5
+        assert TimeUnitConverter.convert_value(1.0, "ms", "s") == 0.001
+
+        # Same unit (no conversion)
+        assert TimeUnitConverter.convert_value(5.0, "s", "s") == 5.0
+        assert TimeUnitConverter.convert_value(5000.0, "ms", "ms") == 5000.0
+
+    def test_none_values(self):
+        """Test conversion with None values."""
+        assert TimeUnitConverter.convert_value(None, "s", "ms") is None
+        assert TimeUnitConverter.convert_value(None, "ms", "s") is None
+
+    def test_invalid_conversion(self):
+        """Test invalid unit conversion raises error."""
+        with pytest.raises(ValueError):
+            TimeUnitConverter.convert_value(1.0, "s", "invalid")
+
+        with pytest.raises(ValueError):
+            TimeUnitConverter.convert_value(1.0, "invalid", "s")
+
+    def test_label_conversion(self):
+        """Test label unit conversion."""
+        # Basic label updates
+        assert TimeUnitConverter.get_unit_label("TTFT", "ms") == "TTFT"
+        assert TimeUnitConverter.get_unit_label("TTFT (s)", "ms") == "TTFT (ms)"
+        assert (
+            TimeUnitConverter.get_unit_label("End-to-End Latency per Request (s)", "ms")
+            == "End-to-End Latency per Request (ms)"
+        )
+
+        # No change for seconds
+        assert TimeUnitConverter.get_unit_label("TTFT (s)", "s") == "TTFT (s)"
+
+    def test_metrics_dict_conversion(self):
+        """Test conversion of metrics dictionary."""
+        test_metrics = {
+            "ttft": 1.5,
+            "e2e_latency": 2.3,
+            "tpot": 0.1,
+            "output_latency": 1.0,
+            "throughput": 100,  # Should not be converted
+            "stats": {
+                "ttft": {"mean": 1.5, "p90": 2.0, "p99": 2.5},
+                "e2e_latency": {"mean": 2.3, "p90": 3.0, "p99": 3.5},
+                "throughput": {"mean": 100, "p90": 120},  # Should not be converted
+            },
+        }
+
+        converted = TimeUnitConverter.convert_metrics_dict(test_metrics, "ms")
+
+        # Check direct fields are converted
+        assert converted["ttft"] == 1500.0
+        assert converted["e2e_latency"] == 2300.0
+        assert converted["tpot"] == 100.0
+        assert converted["output_latency"] == 1000.0
+
+        # Check non-time field is unchanged
+        assert converted["throughput"] == 100
+
+        # Check stats are converted
+        assert converted["stats"]["ttft"]["mean"] == 1500.0
+        assert converted["stats"]["ttft"]["p90"] == 2000.0
+        assert converted["stats"]["ttft"]["p99"] == 2500.0
+        assert converted["stats"]["e2e_latency"]["mean"] == 2300.0
+
+        # Check non-time stats are unchanged
+        assert converted["stats"]["throughput"]["mean"] == 100
+
+        # Check that no conversion happens for seconds
+        converted_s = TimeUnitConverter.convert_metrics_dict(test_metrics, "s")
+        assert converted_s == test_metrics
+
+    def test_metrics_list_conversion(self):
+        """Test conversion of list of metrics dictionaries."""
+        test_metrics_list = [
+            {"ttft": 1.0, "throughput": 50},
+            {"ttft": 1.5, "throughput": 75},
+            {"ttft": 2.0, "throughput": 100},
+        ]
+
+        converted = TimeUnitConverter.convert_metrics_list(test_metrics_list, "ms")
+
+        assert len(converted) == 3
+        assert converted[0]["ttft"] == 1000.0
+        assert converted[1]["ttft"] == 1500.0
+        assert converted[2]["ttft"] == 2000.0
+
+        # Check non-time fields unchanged
+        assert converted[0]["throughput"] == 50
+        assert converted[1]["throughput"] == 75
+        assert converted[2]["throughput"] == 100
+
+    def test_unit_validation(self):
+        """Test unit validation and normalization."""
+        assert TimeUnitConverter.validate_unit("s") == "s"
+        assert TimeUnitConverter.validate_unit("sec") == "s"
+        assert TimeUnitConverter.validate_unit("second") == "s"
+        assert TimeUnitConverter.validate_unit("seconds") == "s"
+
+        assert TimeUnitConverter.validate_unit("ms") == "ms"
+        assert TimeUnitConverter.validate_unit("millisecond") == "ms"
+        assert TimeUnitConverter.validate_unit("milliseconds") == "ms"
+
+        with pytest.raises(ValueError):
+            TimeUnitConverter.validate_unit("invalid")
+
+    def test_is_latency_field(self):
+        """Test latency field detection."""
+        assert TimeUnitConverter.is_latency_field("ttft") is True
+        assert TimeUnitConverter.is_latency_field("tpot") is True
+        assert TimeUnitConverter.is_latency_field("e2e_latency") is True
+        assert TimeUnitConverter.is_latency_field("output_latency") is True
+
+        assert TimeUnitConverter.is_latency_field("throughput") is False
+        assert TimeUnitConverter.is_latency_field("num_tokens") is False
+        assert TimeUnitConverter.is_latency_field("error_rate") is False

--- a/tests/ui/test_dashboard.py
+++ b/tests/ui/test_dashboard.py
@@ -65,7 +65,7 @@ def test_handle_single_request_no_error(mock_dashboard: create_dashboard):
     )
 
     mock_dashboard.update_metrics_panels.assert_called_once_with(live_metrics, "s")
-    mock_dashboard.update_histogram_panel.assert_called_once_with(live_metrics)
+    mock_dashboard.update_histogram_panel.assert_called_once_with(live_metrics, "s")
 
 
 # Test for handle_single_request method when an error occurs
@@ -142,7 +142,7 @@ def test_update_histogram_panel(mock_dashboard: create_dashboard):
     mock_dashboard.layout["input_histogram"].update = MagicMock()
     mock_dashboard.layout["output_histogram"].update = MagicMock()
 
-    mock_dashboard.update_histogram_panel(live_metrics)
+    mock_dashboard.update_histogram_panel(live_metrics, "s")
 
     mock_dashboard.layout["input_histogram"].update.assert_called()
     mock_dashboard.layout["output_histogram"].update.assert_called()

--- a/tests/ui/test_dashboard.py
+++ b/tests/ui/test_dashboard.py
@@ -9,6 +9,7 @@ from genai_bench.ui.dashboard import (
     RichLiveDashboard,
     create_dashboard,
 )
+from genai_bench.ui.plots import create_scatter_plot
 
 
 # Helper function to calculate stats for live metrics
@@ -165,3 +166,46 @@ def test_dashboard_factory_with_env_var(monkeypatch, enable_ui, expected_type):
 
     dashboard = create_dashboard("s")
     assert isinstance(dashboard, expected_type)
+
+
+def test_scatter_plot_spacing_for_different_time_units():
+    """Test that scatter plot spacing is correct for seconds vs milliseconds."""
+    # Test data
+    x_values = [100, 200, 300, 400, 500]
+    y_values = [0.5, 1.0, 1.5, 2.0, 2.5]
+
+    # Test with seconds
+    plot_s = create_scatter_plot(x_values, y_values, y_unit="s")
+    plot_s_str = str(plot_s)
+
+    # Test with milliseconds
+    plot_ms = create_scatter_plot(x_values, y_values, y_unit="ms")
+    plot_ms_str = str(plot_ms)
+
+    # Check that seconds plot uses 7 spaces for labels
+    lines_s = plot_s_str.split("\n")
+    label_line_s = None
+    for line in lines_s:
+        if "2.5" in line and "s" in line:
+            label_line_s = line
+            break
+
+    assert label_line_s is not None, "Could not find label line with seconds"
+
+    # Check that milliseconds plot uses 9 spaces for labels
+    lines_ms = plot_ms_str.split("\n")
+    label_line_ms = None
+    for line in lines_ms:
+        if "2.5" in line and "ms" in line:  # Scatter plot doesn't convert values
+            label_line_ms = line
+            break
+
+    assert label_line_ms is not None, "Could not find label line with milliseconds"
+
+    # Verify the label spacing
+    assert (
+        label_line_s.index("|") == 7
+    ), f"Expected 7 spaces for seconds, got: {label_line_s.index('|')}"
+    assert (
+        label_line_ms.index("|") == 9
+    ), f"Expected 9 spaces for milliseconds, got: {label_line_ms.index('|')}"


### PR DESCRIPTION
## Motivation:
Some users would prefer using milliseconds for latency measures (TTFT, E2E Latency, etc.) rather than seconds. See also: https://github.com/sgl-project/genai-bench/issues/4

## Features added:

- Added `--time-unit [s|ms]` to select the desired unit for latency measures to `genai-bench benchmark`, `genai-bench excel` and `genai-bench plot`
- Updated docs and added tests

For benchmarking:

- The specified time unit (seconds by default) is written into the experiment metadata
- The generated excel sheet, and intermediate plots on the dashboard will have their values and labels modified accordingly (e.g., the old TTFT label will now read TTFT (s) or TTFT (ms)).

For excel:

- Time unit is specified for latency measures in the column headers
- Values are converted from the source time unit (derived from experiment metadata) to whatever the desired time unit is (defaults to seconds)

For plots:

- `genai-bench plot` now takes additional argument `--time-unit [s|ms]`.
- When the time unit is not specified, all generated plots default to using seconds to measure latency.

## Images:

Latency plot in ms. The plot is generated from an older experiment that was run with seconds as the time unit by passing `--time-unit ms` as an argument when running `genai-bench plot`:
<img width="1084" height="590" alt="image" src="https://github.com/user-attachments/assets/6d8493c8-06ab-40ca-8994-59d3bc29a214" />

Dashboard of a run in progress with ms enabled. The graphs, histograms, and latency panels are updated:
<img width="1903" height="601" alt="image" src="https://github.com/user-attachments/assets/3bcde05a-0b1e-4022-b4a9-520f35f7bd8f" />


Screenshots of a spreadsheet generated with `--time-unit ms`:

Appendix:
<img width="2964" height="440" alt="image" src="https://github.com/user-attachments/assets/df7908e7-0f12-47bd-b1d4-79fa0516a626" />

Part of the Aggregated Metrics Sheet (values have been multiplied by 1000 for ms):
<img width="2058" height="1312" alt="image" src="https://github.com/user-attachments/assets/df0a7b55-be47-440b-a85f-8c0235207999" />

Part of the individual request metrics sheet:
<img width="491" height="127" alt="image" src="https://github.com/user-attachments/assets/b0460e53-8482-4371-933f-6ae81f64dded" />

For the excel sheets, units are specified when using seconds or milliseconds - ttft (ms) becomes ttft (s), for instance.
