### PR TITLE
[CI] add GHCR publish to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3
@@ -104,6 +104,7 @@ jobs:
             PKG_VERSION=${{ steps.version.outputs.version }}
           tags: |
             ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:latest
+            ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:${{ steps.version.outputs.tag }}
             ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
         type: string
 
 env:
-  GHCR_NAMESPACE: ${{ toLower(github.repository_owner) }}
+  GHCR_NAMESPACE: ${{ github.repository_owner }}
 
 jobs:
   release:
@@ -103,8 +103,8 @@ jobs:
           build-args: |
             PKG_VERSION=${{ steps.version.outputs.version }}
           tags: |
-            ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:latest
-            ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:${{ steps.version.outputs.tag }}
-            ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/genai-bench:latest
+            ghcr.io/${{ github.repository_owner }}/genai-bench:${{ steps.version.outputs.tag }}
+            ghcr.io/${{ github.repository_owner }}/genai-bench:${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,6 @@ name: Release
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "Tag to test (e.g., v0.0.3-rc.1)"
-        required: true
-        type: string
 
 jobs:
   release:
@@ -44,14 +38,10 @@ jobs:
         run: |
           uv run coverage report --fail-under=93
 
-      - name: Extract version from tag (release or manual)
+      - name: Extract version from release tag
         id: version
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ inputs.tag }}"
-          else
-            TAG="${{ github.event.release.tag_name }}"
-          fi
+          TAG="${{ github.event.release.tag_name }}"
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "version=${TAG#v}" >> $GITHUB_OUTPUT
 
@@ -73,7 +63,6 @@ jobs:
         run: uv build
 
       - name: Publish to PyPI
-        if: github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
@@ -94,7 +83,7 @@ jobs:
       - name: Set GHCR namespace (lowercase)
         run: echo "GHCR_NAMESPACE=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
 
-      - name: Build and push Docker image
+      - name: Build and push Docker image (release)
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_PAT }}
 
       - name: Set GHCR namespace (lowercase)
         run: echo "GHCR_NAMESPACE=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,15 @@ jobs:
         run: |
           uv run coverage report --fail-under=93
 
+      # 1) version from GitHub Release tag
+      - name: Extract version from release tag
+        id: tagver
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+
+      # 2) version from pyproject.toml
       - name: Read version from pyproject.toml
         id: projver
         run: |
@@ -47,6 +56,7 @@ jobs:
           print(f"version={data['project']['version']}")
           PY
 
+      # 3) verify versions match
       - name: Extract version from pyproject.toml
         id: tagver
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to test (e.g., v0.0.3-rc.1)"
+        required: true
+        type: string
 
 jobs:
   release:
@@ -38,10 +44,14 @@ jobs:
         run: |
           uv run coverage report --fail-under=93
 
-      - name: Extract version from release tag
+      - name: Extract version from tag (release or manual)
         id: version
         run: |
-          TAG="${{ github.event.release.tag_name }}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+          fi
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "version=${TAG#v}" >> $GITHUB_OUTPUT
 
@@ -63,6 +73,7 @@ jobs:
         run: uv build
 
       - name: Publish to PyPI
+        if: github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
@@ -83,7 +94,7 @@ jobs:
       - name: Set GHCR namespace (lowercase)
         run: echo "GHCR_NAMESPACE=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
 
-      - name: Build and push Docker image (release)
+      - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -96,3 +107,6 @@ jobs:
             ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Check git diff
+        run: git diff pyproject.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,6 @@ name: Release
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: "Run release in dry mode"
-        required: false
-        default: "true"
 
 jobs:
   release:
@@ -56,22 +50,15 @@ jobs:
       - name: Extract version from pyproject.toml
         id: tagver
         run: |
-          # use pyproject version
           echo "tag=v${{ steps.projver.outputs.version }}" >> $GITHUB_OUTPUT
           echo "version=${{ steps.projver.outputs.version }}" >> $GITHUB_OUTPUT
 
-      - name: Debug - Show extracted versions
-        run: |
-          echo "::notice ::Tag version: ${{ steps.tagver.outputs.version }}"
-          echo "::notice ::pyproject.toml version: ${{ steps.projver.outputs.version }}"
-          echo "Raw tag value: ${{ github.event.release.tag_name }}"
-          
       - name: Verify versions match
         run: |
           echo "Tag version:       ${{ steps.tagver.outputs.version }}"
           echo "pyproject version: ${{ steps.projver.outputs.version }}"
           if [ "${{ steps.tagver.outputs.version }}" != "${{ steps.projver.outputs.version }}" ]; then
-            echo "::error ::Release tag (v${{ steps.tagver.outputs.version }}) must match pyproject.toml version (${{ steps.projver.outputs.version }}). Please ensure the tag matches 'v${{ steps.projver.outputs.version }}'"
+            echo "::error ::Release tag must match pyproject.toml version."
             exit 1
           fi
 
@@ -79,7 +66,6 @@ jobs:
         run: uv build
 
       - name: Publish to PyPI
-        if: ${{ github.event_name == 'release' && inputs.dry_run != 'true' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,25 @@ on:
   release:
     types: [published]
 
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g., v0.1.0rc1)'
+        required: true
+        type: string
+env:
+  REGISTRY: ghcr.io
+  IMAGE_ORG: moirai-internal 
+
+permissions:
+  id-token: write
+  contents: read
+  packages: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
     environment: release
-    permissions:
-      id-token: write
-      contents: read
-      packages: write
 
     steps:
       - uses: actions/checkout@v4
@@ -39,13 +50,22 @@ jobs:
           uv run coverage report --fail-under=93
 
       # 1) version from GitHub Release tag
-      - name: Extract version from release tag
+      - name: Extract version
         id: tagver
         run: |
-          TAG="${{ github.event.release.tag_name }}"
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAG="${{ github.event.release.tag_name }}"
+          else
+            TAG="${{ inputs.tag }}"
+          fi
+          if [ -z "$TAG" ]; then
+            echo "::error ::Tag is required (e.g., v0.1.0rc1)."
+            exit 1
+          fi
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "version=${TAG#v}" >> $GITHUB_OUTPUT
-
+          echo "Resolved tag=$TAG, version=${TAG#v}"
+          
       # 2) version from pyproject.toml
       - name: Read version from pyproject.toml
         id: projver
@@ -57,12 +77,6 @@ jobs:
           PY
 
       # 3) verify versions match
-      - name: Extract version from pyproject.toml
-        id: tagver
-        run: |
-          echo "tag=v${{ steps.projver.outputs.version }}" >> $GITHUB_OUTPUT
-          echo "version=${{ steps.projver.outputs.version }}" >> $GITHUB_OUTPUT
-
       - name: Verify versions match
         run: |
           echo "Tag version:       ${{ steps.tagver.outputs.version }}"
@@ -76,6 +90,7 @@ jobs:
         run: uv build
 
       - name: Publish to PyPI
+        if: github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
@@ -90,12 +105,9 @@ jobs:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
-
-      - name: Set GHCR namespace (lowercase)
-        run: echo "GHCR_NAMESPACE=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
 
       - name: Build and push Docker image (release)
         uses: docker/build-push-action@v6
@@ -106,7 +118,7 @@ jobs:
           build-args: |
             PKG_VERSION=${{ steps.tagver.outputs.version }}
           tags: |
-            ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:latest
-            ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:${{ steps.tagver.outputs.version }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_ORG }}/genai-bench:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_ORG }}/genai-bench:${{ steps.tagver.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     permissions:
-      id-token: write # For trusted publishing (optional but recommended)
+      id-token: write   # For trusted publishing (optional but recommended)
       contents: read
-      packages: write # For publishing Docker images to GHCR
+      packages: write   # For publishing Docker images to GHCR
 
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
           TAG="${{ github.event.release.tag_name }}"
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "version=${TAG#v}" >> $GITHUB_OUTPUT
-      
+
       - name: Sync pyproject.toml version
         run: |
           python - <<'PY'
@@ -58,6 +58,7 @@ jobs:
           PY
         env:
           VERSION: ${{ steps.version.outputs.version }}
+
       - name: Build package
         run: |
           uv build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,6 @@ jobs:
             PKG_VERSION=${{ steps.version.outputs.version }}
           tags: |
             ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:latest
-            ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:${{ steps.version.outputs.tag }}
             ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,6 @@ name: Release
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "Tag to test (e.g., v0.0.3-rc.1)"
-        required: true
-        type: string
 
 jobs:
   release:
@@ -25,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: "3.11"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3
@@ -34,6 +28,7 @@ jobs:
         run: |
           uv pip install --system .
           uv pip install --system ".[dev,multi-cloud]"
+
       - name: Run tests
         run: |
           uv run pytest tests --cov --cov-report=term-missing -v
@@ -42,16 +37,14 @@ jobs:
       - name: Check coverage threshold
         run: |
           uv run coverage report --fail-under=93
-      - name: Extract version from tag (release or manual)
+
+      - name: Extract version from release tag
         id: version
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ inputs.tag }}"
-          else
-            TAG="${{ github.event.release.tag_name }}"
-          fi
+          TAG="${{ github.event.release.tag_name }}"
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+
       - name: Sync pyproject.toml version
         run: |
           python - <<'PY'
@@ -70,7 +63,6 @@ jobs:
         run: uv build
 
       - name: Publish to PyPI
-        if: github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
@@ -86,12 +78,12 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }} 
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set GHCR namespace (lowercase)
         run: echo "GHCR_NAMESPACE=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
 
-      - name: Build and push Docker image
+      - name: Build and push Docker image (release)
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -101,9 +93,6 @@ jobs:
             PKG_VERSION=${{ steps.version.outputs.version }}
           tags: |
             ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:latest
-            ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:${{ steps.version.outputs.tag }}
             ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      - name: Check git diff
-        run: git diff pyproject.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       id-token: write # For trusted publishing (optional but recommended)
       contents: read
+      packages: write # For publishing Docker images to GHCR
 
     steps:
       - uses: actions/checkout@v4
@@ -37,6 +38,26 @@ jobs:
         run: |
           uv run coverage report --fail-under=93
 
+      - name: Extract version from release tag
+        id: version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+      
+      - name: Sync pyproject.toml version
+        run: |
+          python - <<'PY'
+          import pathlib, re, os
+          p = pathlib.Path("pyproject.toml")
+          s = p.read_text(encoding="utf-8")
+          ver = os.environ["VERSION"]
+          s = re.sub(r'(?m)^(version\s*=\s*")[^"]+(")', rf'version = "{ver}"', s)
+          p.write_text(s, encoding="utf-8")
+          print("Updated pyproject.toml to", ver)
+          PY
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
       - name: Build package
         run: |
           uv build
@@ -47,3 +68,31 @@ jobs:
           password: ${{ secrets.PYPI_API_TOKEN }}
           # For trusted publishing (more secure, optional):
           # repository-url: https://upload.pypi.org/legacy/
+
+      - name: Set up QEMU (for multi-arch)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            PKG_VERSION=${{ steps.version.outputs.version }}
+          tags: |
+            ghcr.io/moirai-internal/genai-bench:latest
+            ghcr.io/moirai-internal/genai-bench:${{ steps.version.outputs.tag }}      # v0.0.3
+            ghcr.io/moirai-internal/genai-bench:${{ steps.version.outputs.version }}  # 0.0.3
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: "3.11"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3
@@ -34,7 +34,6 @@ jobs:
         run: |
           uv pip install --system .
           uv pip install --system ".[dev,multi-cloud]"
-
       - name: Run tests
         run: |
           uv run pytest tests --cov --cov-report=term-missing -v
@@ -43,7 +42,6 @@ jobs:
       - name: Check coverage threshold
         run: |
           uv run coverage report --fail-under=93
-
       - name: Extract version from tag (release or manual)
         id: version
         run: |
@@ -54,7 +52,6 @@ jobs:
           fi
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "version=${TAG#v}" >> $GITHUB_OUTPUT
-
       - name: Sync pyproject.toml version
         run: |
           python - <<'PY'
@@ -89,7 +86,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }} 
 
       - name: Set GHCR namespace (lowercase)
         run: echo "GHCR_NAMESPACE=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
@@ -108,6 +105,3 @@ jobs:
             ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Check git diff
-        run: git diff pyproject.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,15 +3,24 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to test (e.g., v0.0.3-rc.1)"
+        required: true
+        type: string
+
+env:
+  GHCR_NAMESPACE: ${{ github.repository_owner }}
 
 jobs:
   release:
     runs-on: ubuntu-latest
     environment: release
     permissions:
-      id-token: write   # For trusted publishing (optional but recommended)
+      id-token: write
       contents: read
-      packages: write   # For publishing Docker images to GHCR
+      packages: write
 
     steps:
       - uses: actions/checkout@v4
@@ -38,10 +47,14 @@ jobs:
         run: |
           uv run coverage report --fail-under=93
 
-      - name: Extract version from release tag
+      - name: Extract version from tag (release or manual)
         id: version
         run: |
-          TAG="${{ github.event.release.tag_name }}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+          fi
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "version=${TAG#v}" >> $GITHUB_OUTPUT
 
@@ -60,15 +73,13 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
 
       - name: Build package
-        run: |
-          uv build
+        run: uv build
 
       - name: Publish to PyPI
+        if: github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
-          # For trusted publishing (more secure, optional):
-          # repository-url: https://upload.pypi.org/legacy/
 
       - name: Set up QEMU (for multi-arch)
         uses: docker/setup-qemu-action@v3
@@ -92,8 +103,8 @@ jobs:
           build-args: |
             PKG_VERSION=${{ steps.version.outputs.version }}
           tags: |
-            ghcr.io/moirai-internal/genai-bench:latest
-            ghcr.io/moirai-internal/genai-bench:${{ steps.version.outputs.tag }}      # v0.0.3
-            ghcr.io/moirai-internal/genai-bench:${{ steps.version.outputs.version }}  # 0.0.3
+            ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:latest
+            ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:${{ steps.version.outputs.tag }}
+            ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,6 @@ on:
         required: true
         type: string
 
-env:
-  GHCR_NAMESPACE: ${{ github.repository_owner }}
-
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -94,6 +91,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set GHCR namespace (lowercase)
+        run: echo "GHCR_NAMESPACE=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
@@ -103,8 +103,8 @@ jobs:
           build-args: |
             PKG_VERSION=${{ steps.version.outputs.version }}
           tags: |
-            ghcr.io/${{ github.repository_owner }}/genai-bench:latest
-            ghcr.io/${{ github.repository_owner }}/genai-bench:${{ steps.version.outputs.tag }}
-            ghcr.io/${{ github.repository_owner }}/genai-bench:${{ steps.version.outputs.version }}
+            ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:latest
+            ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:${{ steps.version.outputs.tag }}
+            ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,12 @@ name: Release
 on:
   release:
     types: [published]
-
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run release in dry mode"
+        required: false
+        default: "true"
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -39,25 +44,35 @@ jobs:
           uv run coverage report --fail-under=93
 
       - name: Extract version from release tag
-        id: version
+        id: tagver
         run: |
           TAG="${{ github.event.release.tag_name }}"
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "version=${TAG#v}" >> $GITHUB_OUTPUT
 
-      - name: Sync pyproject.toml version
+      - name: Read version from pyproject.toml
+        id: projver
         run: |
-          python - <<'PY'
-          import pathlib, re, os
-          p = pathlib.Path("pyproject.toml")
-          s = p.read_text(encoding="utf-8")
-          ver = os.environ["VERSION"]
-          s = re.sub(r'(?m)^(version\s*=\s*")[^"]+(")', rf'version = "{ver}"', s)
-          p.write_text(s, encoding="utf-8")
-          print("Updated pyproject.toml to", ver)
+          python - <<'PY' | tee /dev/stderr | awk -F= '/^version=/{print "version="$2}' >> "$GITHUB_OUTPUT"
+          import tomllib, pathlib, sys
+          data = tomllib.loads(pathlib.Path("pyproject.toml").read_text("utf-8"))
+          print(f"version={data['project']['version']}")
           PY
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
+
+      - name: Debug - Show extracted versions
+        run: |
+          echo "::notice ::Tag version: ${{ steps.tagver.outputs.version }}"
+          echo "::notice ::pyproject.toml version: ${{ steps.projver.outputs.version }}"
+          echo "Raw tag value: ${{ github.event.release.tag_name }}"
+          
+      - name: Verify tag matches pyproject version
+        run: |
+          echo "Tag version:       ${{ steps.tagver.outputs.version }}"
+          echo "pyproject version: ${{ steps.projver.outputs.version }}"
+          if [ "${{ steps.tagver.outputs.version }}" != "${{ steps.projver.outputs.version }}" ]; then
+            echo "::error ::Release tag must match pyproject.toml version."
+            exit 1
+          fi
 
       - name: Build package
         run: uv build
@@ -67,6 +82,7 @@ jobs:
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
 
+      # --- Docker publish ---
       - name: Set up QEMU (for multi-arch)
         uses: docker/setup-qemu-action@v3
 
@@ -90,9 +106,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
-            PKG_VERSION=${{ steps.version.outputs.version }}
+            PKG_VERSION=${{ steps.tagver.outputs.version }}
           tags: |
             ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:latest
-            ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:${{ steps.version.outputs.version }}
+            ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:${{ steps.tagver.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
         description: "Run release in dry mode"
         required: false
         default: "true"
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -43,13 +44,6 @@ jobs:
         run: |
           uv run coverage report --fail-under=93
 
-      - name: Extract version from release tag
-        id: tagver
-        run: |
-          TAG="${{ github.event.release.tag_name }}"
-          echo "tag=${TAG}" >> $GITHUB_OUTPUT
-          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
-
       - name: Read version from pyproject.toml
         id: projver
         run: |
@@ -59,18 +53,25 @@ jobs:
           print(f"version={data['project']['version']}")
           PY
 
+      - name: Extract version from release tag (if exists)
+        id: tagver
+        run: |
+          # use pyproject version
+          echo "tag=v${{ steps.projver.outputs.version }}" >> $GITHUB_OUTPUT
+          echo "version=${{ steps.projver.outputs.version }}" >> $GITHUB_OUTPUT
+
       - name: Debug - Show extracted versions
         run: |
           echo "::notice ::Tag version: ${{ steps.tagver.outputs.version }}"
           echo "::notice ::pyproject.toml version: ${{ steps.projver.outputs.version }}"
           echo "Raw tag value: ${{ github.event.release.tag_name }}"
           
-      - name: Verify tag matches pyproject version
+      - name: Verify versions match
         run: |
           echo "Tag version:       ${{ steps.tagver.outputs.version }}"
           echo "pyproject version: ${{ steps.projver.outputs.version }}"
           if [ "${{ steps.tagver.outputs.version }}" != "${{ steps.projver.outputs.version }}" ]; then
-            echo "::error ::Release tag must match pyproject.toml version."
+            echo "::error ::Release tag (v${{ steps.tagver.outputs.version }}) must match pyproject.toml version (${{ steps.projver.outputs.version }}). Please ensure the tag matches 'v${{ steps.projver.outputs.version }}'"
             exit 1
           fi
 
@@ -78,18 +79,22 @@ jobs:
         run: uv build
 
       - name: Publish to PyPI
+        if: ${{ github.event_name == 'release' && inputs.dry_run != 'true' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
 
       # --- Docker publish ---
       - name: Set up QEMU (for multi-arch)
+        if: ${{ inputs.dry_run != 'true' }}
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
+        if: ${{ inputs.dry_run != 'true' }}
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
+        if: ${{ inputs.dry_run != 'true' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -97,9 +102,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set GHCR namespace (lowercase)
+        if: ${{ inputs.dry_run != 'true' }}
         run: echo "GHCR_NAMESPACE=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
 
       - name: Build and push Docker image (release)
+        if: ${{ inputs.dry_run != 'true' }}
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
         type: string
 
 env:
-  GHCR_NAMESPACE: ${{ github.repository_owner }}
+  GHCR_NAMESPACE: ${{ toLower(github.repository_owner) }}
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           print(f"version={data['project']['version']}")
           PY
 
-      - name: Extract version from release tag (if exists)
+      - name: Extract version from pyproject.toml
         id: tagver
         run: |
           # use pyproject version
@@ -86,15 +86,12 @@ jobs:
 
       # --- Docker publish ---
       - name: Set up QEMU (for multi-arch)
-        if: ${{ inputs.dry_run != 'true' }}
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        if: ${{ inputs.dry_run != 'true' }}
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        if: ${{ inputs.dry_run != 'true' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -102,11 +99,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set GHCR namespace (lowercase)
-        if: ${{ inputs.dry_run != 'true' }}
         run: echo "GHCR_NAMESPACE=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
 
       - name: Build and push Docker image (release)
-        if: ${{ inputs.dry_run != 'true' }}
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3
@@ -105,3 +105,5 @@ jobs:
             ghcr.io/${{ env.GHCR_NAMESPACE }}/genai-bench:${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Check git diff
+        run: git diff pyproject.toml


### PR DESCRIPTION
## Motivation
- Ship an official Docker image to **GHCR** as part of each release, alongside the **PyPI** package.  
- Ensure a **single source of truth** for versioning by updating `pyproject.toml` in a PR before creating the release.  
- Provide **multi-arch images** (`linux/amd64`, `linux/arm64`) for broader runtime support.  
- Use the **moirai-internal namespace** in GHCR, which has specific write permissions to ensure controlled publishing.  

## Features Added

### 1) Version management workflow (manual bump → release)
We now **manually update `pyproject.toml`** in a PR, merge it, and then create the **tag/release** from that commit.  
This ensures the tag, release metadata, and `pyproject.toml` version always match.  

**Pros**
- **Single source of truth** — `pyproject.toml` always reflects the real current version.  
- **Consistency** — release tag, package metadata, and code stay aligned.  
- **Auditable** — version bumps land in PRs/commits, easier to review.  

### 2) GHCR publishing on release
- Registry: `ghcr.io/moirai-internal/genai-bench`  
- Tags pushed: `latest`, `X.Y.Z`  
- Auth: uses `secrets.GHCR_PAT` (scoped for `moirai-internal`)  
- Owner normalized to lowercase via `GHCR_NAMESPACE=${GITHUB_REPOSITORY_OWNER,,}` (GHCR requirement)  

### 3) Multi-arch Docker build
- QEMU + Buildx for `linux/amd64` and `linux/arm64`  
- GHA cache enabled for faster builds  

## Tests Performed (on my fork)

All validation was done on my **fork** repo (`Juno13340/genai-bench`, branch `genyi/include-docker-image`) to avoid touching upstream.  
Docker images were published under my fork’s namespace **`ghcr.io/juno13340`**, not the upstream org.  

- **GitHub Actions run**  
  <img width="2048" height="1818" alt="image" src="https://github.com/user-attachments/assets/6ac76497-e13d-40b9-ab97-3cb3942426f5" />  

- **Local pull & inspect**  
  ```bash
  # pull succeeds
  docker pull ghcr.io/juno13340/genai-bench:0.0.3-rc.1

  # inspect shows multi-arch (amd64 + arm64) manifests
  docker buildx imagetools inspect ghcr.io/juno13340/genai-bench:0.0.3-rc.1
