### PR TITLE
[Docs] Add PR template and remove duplicate PR section from contributing guide

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,9 @@ Please prefix your PR title with one of the following:
 - [ ] `[Report]` - Changes in generating plots and excel reports
 - [ ] `[Misc]` - Other changes (use sparingly)
 
+## Related Issue
+Link the related issue: #<issue_number>
+
 ## Changes Made in this PR
 - [ ] Change 1  
 - [ ] Change 2 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,4 +33,4 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 - [ ] My changes are concise and focused on a single purpose
 
 ## Additional Information
-Add any other context, screenshots, or information about the PR here.  
+Add any other context, screenshots, or information about the PR here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,12 +25,6 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 ## Checklist
 - [ ] I have rebased my branch on top of the latest main branch (`git pull origin main`)
 - [ ] I have run `make check` to ensure code is properly formatted and passes all lint checks
-- [ ] I have run `make test` or `make test_changed` to verify test coverage (~90% required)
-- [ ] I have added tests that fail without my code changes (for bug fixes)
-- [ ] I have added tests covering variants of new features (for new features)
-- [ ] My commit message title is within 52 characters
-- [ ] Each line in my commit message content is within 72 characters
-- [ ] My changes are concise and focused on a single purpose
 
 ## Additional Information
 Add any other context, screenshots, or information about the PR here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,7 @@ Link the related issue: #<issue_number>
 - [ ] Change 1
 - [ ] Change 2
 
-## How Has This Been Tested? 
+## How Has This Been Tested?
 Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
 
 ## Checklist

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+## Description
+Please provide a brief description of the changes in this PR.
+
+## Type of Change
+Please prefix your PR title with one of the following:
+- [ ] `[Bugfix]` - Bug fixes
+- [ ] `[Core]` - Core backend changes (build, version upgrade, changes in user and sampling)
+- [ ] `[Metrics]` - Changes made to metrics
+- [ ] `[Frontend]` - UI dashboard and CLI entrypoint related changes
+- [ ] `[Docs]` - Documentation changes
+- [ ] `[CI/Tests]` - Unit tests and integration tests
+- [ ] `[Report]` - Changes in generating plots and excel reports
+- [ ] `[Misc]` - Other changes (use sparingly)
+
+## Changes Made in this PR
+- [ ] Change 1  
+- [ ] Change 2 
+
+## How Has This Been Tested? 
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
+
+## Checklist
+- [ ] I have rebased my branch on top of the latest main branch (`git pull origin main`)
+- [ ] I have run `make check` to ensure code is properly formatted and passes all lint checks
+- [ ] I have run `make test` or `make test_changed` to verify test coverage (~90% required)
+- [ ] I have added tests that fail without my code changes (for bug fixes)
+- [ ] I have added tests covering variants of new features (for new features)
+- [ ] My commit message title is within 52 characters
+- [ ] Each line in my commit message content is within 72 characters
+- [ ] My changes are concise and focused on a single purpose
+
+## Additional Information
+Add any other context, screenshots, or information about the PR here.  

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,8 +16,8 @@ Please prefix your PR title with one of the following:
 Link the related issue: #<issue_number>
 
 ## Changes Made in this PR
-- [ ] Change 1  
-- [ ] Change 2 
+- [ ] Change 1
+- [ ] Change 2
 
 ## How Has This Been Tested? 
 Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,6 +25,9 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 ## Checklist
 - [ ] I have rebased my branch on top of the latest main branch (`git pull origin main`)
 - [ ] I have run `make check` to ensure code is properly formatted and passes all lint checks
+- [ ] I have run `make test` or `make test_changed` to verify test coverage (~90% required)
+- [ ] I have added tests that fail without my code changes (for bug fixes)
+- [ ] I have added tests covering variants of new features (for new features)
 
 ## Additional Information
 Add any other context, screenshots, or information about the PR here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,26 +1,35 @@
 ## Description
 Please provide a brief description of the changes in this PR.
 
-## Type of Change
-Please prefix your PR title with one of the following:
-- [ ] `[Bugfix]` - Bug fixes
-- [ ] `[Core]` - Core backend changes (build, version upgrade, changes in user and sampling)
-- [ ] `[Metrics]` - Changes made to metrics
-- [ ] `[Frontend]` - UI dashboard and CLI entrypoint related changes
-- [ ] `[Docs]` - Documentation changes
-- [ ] `[CI/Tests]` - Unit tests and integration tests
-- [ ] `[Report]` - Changes in generating plots and excel reports
-- [ ] `[Misc]` - Other changes (use sparingly)
+## What type of PR is this?
+<!-- 
+Add one of the following:
+/kind Bug
+/kind Core
+/kind Frontend
+/kind Docs
+/kind CI/Tests
+/kind Misc
+-->
 
 ## Related Issue
-Link the related issue: #<issue_number>
+<!-- 
+Automatically closes linked issue when PR is merged.
+Usage: Fixes #<issue number>, or Fixes (paste link of issue).
+-->
+Fixes #<issue_number>
 
 ## Changes Made in this PR
-- [ ] Change 1
-- [ ] Change 2
+<!-- 
+List the changes made in this PR.
+-->
+- [ ] Change 1  
+- [ ] Change 2  
 
 ## How Has This Been Tested?
+<!-- 
 Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
+-->
 
 ## Checklist
 - [ ] I have rebased my branch on top of the latest main branch (`git pull origin main`)

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -11,7 +11,7 @@ We use `make format` to format our code using `isort` and `ruff`. The detailed c
 
 ## Pull Requests
 
-When submitting a pull request, please follow the PR template that will be automatically populated when you open a PR.
+Please follow the PR template, which will be automatically populated when you open a new [Pull Request on GitHub](https://github.com/sgl-project/genai-bench/compare).
 
 ### Code Reviews
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -11,38 +11,7 @@ We use `make format` to format our code using `isort` and `ruff`. The detailed c
 
 ## Pull Requests
 
-When submitting a pull request, please:
-
-1. `git pull origin main` to make sure your code has been rebased on top of the latest commit on the main branch.
-2. Ensure code is properly formatted and passed every lint checks by running `make check`.
-3. Add new test cases to stay robust and correct. In the case of a bug fix, the tests should fail without your code
-changes. For new features, try to cover as many variants as reasonably possible. You can use `make test` to check the
-test coverage. Or use `make test_changed` to test the test coverage for your own branch. We enforce to keep a test
-coverage about 90%.
-
-### PR Template
-
-It is required to classify your PR and make the commit message concise and useful. Prefix the PR title appropriately
-to indicate the type of change. Please use one of the following:
-
-`[Bugfix]` for bug fixes.
-
-`[Core]` for core backend changes. This includes build, version upgrade, changes in user and sampling.
-
-`[Metrics]` for changes made to metrics.
-
-`[Frontend]` for UI dashboard and CLI entrypoint related changes.
-
-`[Docs]` for changes related to documentation.
-
-`[CI/Tests]` for unittests and integration tests.
-
-`[Report]` for changes in generating plots and excel reports.
-
-`[Misc]` for PRs that do not fit the above categories. Please use this sparingly.
-
-Open source community also recommends to keep the commit message title within 52 chars and each line in message content
-within 72 chars.
+When submitting a pull request, please follow the [PR template](../../.github/pull_request_template.md) that will be automatically populated when you open a PR.
 
 ### Code Reviews
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -11,7 +11,7 @@ We use `make format` to format our code using `isort` and `ruff`. The detailed c
 
 ## Pull Requests
 
-When submitting a pull request, please follow the [PR template](../../.github/pull_request_template.md) that will be automatically populated when you open a PR.
+When submitting a pull request, please follow the PR template that will be automatically populated when you open a PR.
 
 ### Code Reviews
 


### PR DESCRIPTION
## Description
This PR introduces a standardized pull request template for **genai-bench**.  
The template consolidates PR requirements previously documented in the contributing guide, ensuring contributors consistently follow the same process when opening a PR.

## Related Issue
Closes #78

## Changes
- Added `.github/pull_request_template.md` including:
  - PR type classification ([Bugfix], [Core], [Docs], etc.)
  - Commit message conventions (title ≤ 52 chars, lines ≤ 72 chars)
  - Checklist for rebasing, linting, testing, and documentation updates
- Updated `docs/development/contributing.md`:
  - Removed duplicate PR requirements section
  - Added a short reference to the PR template

## Checklist
- [x] Rebased branch on top of `main`
- [x] Added PR template file under `.github/`
- [x] Removed duplicate PR requirements from contributing guide
- [x] Verified `make check` and `make test` pass