### PR TITLE
[CI] Remove `--no-reinstall` as it is not supported in uv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ dev: ## Install development dependencies.
 
 .PHONY: test
 test: ## Run tests.
-	uv run --no-reinstall pytest $(TEST_DIR) --cov --cov-config=.coveragerc -vv -s
+	uv run pytest $(TEST_DIR) --cov --cov-config=.coveragerc -vv -s
 
 .PHONY: test_changed
 test_changed: ## Run tests only for changed files with coverage.
@@ -55,7 +55,7 @@ test_changed: ## Run tests only for changed files with coverage.
 	if ! git diff --diff-filter=ACM --quiet --exit-code $$MERGEBASE -- '*.py' '*.pyi' &>/dev/null; then \
 		changed_files=$$(git diff --name-only --diff-filter=ACM $$MERGEBASE -- '*.py' '*.pyi'); \
 		echo "Changed files: $$changed_files"; \
-		uv run --no-reinstall pytest $$changed_files --cov-config=.coveragerc -vv -s; \
+		uv run pytest $$changed_files --cov-config=.coveragerc -vv -s; \
 	else \
 		echo "No Python files have changed."; \
 	fi
@@ -66,13 +66,13 @@ clean: ## Remove build artifacts.
 
 .PHONY: format
 format: ## Format code using ruff.
-	uv run --no-reinstall isort $(SRC_DIR) $(TEST_DIR)
-	uv run --no-reinstall ruff format $(SRC_DIR) $(TEST_DIR); uv run --no-reinstall ruff check --fix $(SRC_DIR) $(TEST_DIR)
+	uv run isort $(SRC_DIR) $(TEST_DIR)
+	uv run ruff format $(SRC_DIR) $(TEST_DIR); uv run  ruff check --fix $(SRC_DIR) $(TEST_DIR)
 
 .PHONY: lint
 lint: ## Run linters using ruff.
-	uv run --no-reinstall ruff format --diff $(SRC_DIR) $(TEST_DIR)
-	uv run --no-reinstall mypy $(SRC_DIR)
+	uv run ruff format --diff $(SRC_DIR) $(TEST_DIR)
+	uv run mypy $(SRC_DIR)
 
 .PHONY: check
 check: format lint ## Run format and lint.


### PR DESCRIPTION
## Description
`--no-reinstall` is not a valid uv option. This PR removes this in Makefile.

## What type of PR is this?
<!-- 
Add one of the following:
/kind Bug
/kind Core
/kind Frontend
/kind Docs
/kind CI/Tests
/kind Misc
-->
/kind CI

## Related Issue
<!-- 
Automatically closes linked issue when PR is merged.
Usage: Fixes #<issue number>, or Fixes (paste link of issue).
-->

## Changes Made in this PR
<!-- 
List the changes made in this PR.
-->

## How Has This Been Tested?
<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

## Checklist
- [x] I have rebased my branch on top of the latest main branch (`git pull origin main`)
- [x] I have run `make check` to ensure code is properly formatted and passes all lint checks
- [x] I have run `make test` or `make test_changed` to verify test coverage (~90% required)
- [x] I have added tests that fail without my code changes (for bug fixes)
- [x] I have added tests covering variants of new features (for new features)

## Additional Information