### PR TITLE
[Core] Extend timeout of oci genai client and improve error handling in distributed workers

### DIFF
--- a/genai_bench/distributed/runner.py
+++ b/genai_bench/distributed/runner.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional, Protocol
 
 import gevent
 import psutil
+from pydantic import ValidationError
 
 from genai_bench.logging import WorkerLoggingManager, init_logger
 from genai_bench.metrics.aggregated_metrics_collector import AggregatedMetricsCollector
@@ -278,7 +279,7 @@ class DistributedRunner:
             # Master receives and aggregates metrics
             try:
                 metrics = RequestLevelMetrics.model_validate_json(msg.data)
-            except Exception as e:
+            except ValidationError as e:
                 logger.warning(
                     f"Dropping invalid metrics record due to validation error: {e}"
                 )

--- a/genai_bench/user/oci_genai_user.py
+++ b/genai_bench/user/oci_genai_user.py
@@ -25,6 +25,10 @@ from genai_bench.user.base_user import BaseUser
 
 logger = init_logger(__name__)
 
+# OCI client timeout constants
+OCI_CONNECT_TIMEOUT = 60
+OCI_READ_TIMEOUT = 300
+
 
 class OCIGenAIUser(BaseUser):
     """User class for OCI GenAI models API with OCI authentication."""
@@ -47,7 +51,10 @@ class OCIGenAIUser(BaseUser):
         signer = self.auth_provider.get_credentials()
 
         self.client = GenerativeAiInferenceClient(
-            config=config, signer=signer, service_endpoint=self.host, timeout=(60, 300)
+            config=config,
+            signer=signer,
+            service_endpoint=self.host,
+            timeout=(OCI_CONNECT_TIMEOUT, OCI_READ_TIMEOUT),
         )
         logger.debug("Generative AI Inference Client initialized.")
 


### PR DESCRIPTION
## Description
This PR resolves two issues faced when benchmark the oci genai endpoint:
- Hit read timeout(60 seconds) when testing some long inference job, so set the (connect_timeout, read_timeout) to (60, 300)
- When use multi-workers mode, the tpot validation error is not properly handled, it causes the worker crash, added proper handling and log the warning

## What type of PR is this?
<!-- 
Add one of the following:
/kind Bug
/kind Core
/kind Frontend
/kind Docs
/kind CI/Tests
/kind Misc
-->
 Bug
## Related Issue
<!-- 
Automatically closes linked issue when PR is merged.
Usage: Fixes #<issue number>, or Fixes (paste link of issue).
-->
N/A

## Changes Made in this PR
<!-- 
List the changes made in this PR.
-->
- [x] Change 1 : change the client read timeout from default 60 to 300s 
- [x] Change 2: add error handling for validation error to avoid crash

## How Has This Been Tested?
<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->
It doesn't timeout and worker doesn't crash after the change
## Checklist
- [x] I have rebased my branch on top of the latest main branch (`git pull origin main`)
- [x] I have run `make check` to ensure code is properly formatted and passes all lint checks
- [x] I have run `make test` or `make test_changed` to verify test coverage (~90% required)
- [x] I have added tests that fail without my code changes (for bug fixes)
- [ ] I have added tests covering variants of new features (for new features)

## Additional Information
Add any other context, screenshots, or information about the PR here.
