### PR TITLE
[UI] Fix Minimal Dashboard

### DIFF
--- a/genai_bench/ui/dashboard.py
+++ b/genai_bench/ui/dashboard.py
@@ -54,7 +54,7 @@ class MinimalDashboard:
         pass
 
     def update_scatter_plot_panel(
-        self, ui_scatter_plot_metrics: Optional[List[float]], time_unit: str = "s"
+        self, _ui_scatter_plot_metrics: Optional[List[float]], _time_unit: str = "s"
     ):
         pass
 

--- a/genai_bench/ui/dashboard.py
+++ b/genai_bench/ui/dashboard.py
@@ -53,7 +53,9 @@ class MinimalDashboard:
     ):
         pass
 
-    def update_scatter_plot_panel(self, ui_scatter_plot_metrics: Optional[List[float]]):
+    def update_scatter_plot_panel(
+        self, ui_scatter_plot_metrics: Optional[List[float]], time_unit: str = "s"
+    ):
         pass
 
     def update_benchmark_progress_bars(self, progress_increment: float):

--- a/tests/ui/test_dashboard.py
+++ b/tests/ui/test_dashboard.py
@@ -209,3 +209,17 @@ def test_scatter_plot_spacing_for_different_time_units():
     assert (
         label_line_ms.index("|") == 9
     ), f"Expected 9 spaces for milliseconds, got: {label_line_ms.index('|')}"
+
+
+def test_minimal_dashboard_update_scatter_plot_does_not_crash():
+    """
+    Ensure MinimalDashboard.update_scatter_plot_panel works without a crash
+    """
+    dashboard = MinimalDashboard("s")
+
+    mock_metrics = [0.1, 0.2, 10.0, 20.0]
+
+    # Calling with metrics and explicit time unit should not raise
+    dashboard.update_scatter_plot_panel(mock_metrics, "s")
+
+    dashboard.update_scatter_plot_panel(mock_metrics, "ms")

--- a/tests/ui/test_dashboard.py
+++ b/tests/ui/test_dashboard.py
@@ -223,3 +223,5 @@ def test_minimal_dashboard_update_scatter_plot_does_not_crash():
     dashboard.update_scatter_plot_panel(mock_metrics, "s")
 
     dashboard.update_scatter_plot_panel(mock_metrics, "ms")
+
+    dashboard.update_scatter_plot_panel(None, "s")


### PR DESCRIPTION
## Description
Bugfix: Fix the following crash with minimal dashboard:
```TypeError: MinimalDashboard.update_scatter_plot_panel() takes 2 positional arguments but 3 were given```

## What type of PR is this?
<!-- 
Add one of the following:
/kind Bug
/kind Core
/kind Frontend
/kind Docs
/kind CI/Tests
/kind Misc
-->
/kind Bug


## Changes Made in this PR
<!-- 

-->
- [ ] Change MinimalDashboard.update_scatter_plot_panel() to accept time_unit: str parameter to prevent a crash
- [ ] Added a test to cover this error


## How Has This Been Tested?
<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->
 - Added a test to make sure the crashing minimaldashboard function doesn't crash
 - To reproduce original error (and verify fix works) prepend `ENABLE_UI=false` to the genai-bench benchmark command. This invokes the MinimalDashboard, which previously would crash but now does not.

## Checklist
- [X] I have rebased my branch on top of the latest main branch (`git pull origin main`)
- [X] I have run `make check` to ensure code is properly formatted and passes all lint checks
- [X] I have run `make test` or `make test_changed` to verify test coverage (~90% required)
- [X] I have added tests that fail without my code changes (for bug fixes)
- [X] I have added tests covering variants of new features (for new features)

