### PR TITLE
[Bugfix] Fix OpenAI authentication header formatting 

### DIFF
--- a/genai_bench/user/openai_user.py
+++ b/genai_bench/user/openai_user.py
@@ -40,8 +40,9 @@ class OpenAIUser(BaseUser):
     def on_start(self):
         if not self.host or not self.auth_provider:
             raise ValueError("API key and base must be set for OpenAIUser.")
+        auth_headers = self.auth_provider.get_headers()
         self.headers = {
-            "Authorization": f"Bearer {self.auth_provider.get_credentials()}",
+            **auth_headers,
             "Content-Type": "application/json",
         }
         super().on_start()

--- a/tests/user/test_openai_user.py
+++ b/tests/user/test_openai_user.py
@@ -19,6 +19,7 @@ def mock_openai_user():
     # Set up mock auth provider
     mock_auth = MagicMock()
     mock_auth.get_credentials.return_value = "fake_api_key"
+    mock_auth.get_headers.return_value = {"Authorization": "Bearer fake_api_key"}
     mock_auth.get_config.return_value = {
         "api_base": "http://example.com",
         "api_key": "fake_api_key",
@@ -27,10 +28,6 @@ def mock_openai_user():
     OpenAIUser.host = "http://example.com"
 
     user = OpenAIUser(environment=MagicMock())
-    user.headers = {
-        "Authorization": "Bearer fake_api_key",
-        "Content-Type": "application/json",
-    }
     user.user_requests = [
         UserChatRequest(
             model="gpt-3",


### PR DESCRIPTION
## Description
Fixes authentication errors when using OpenAI-compatible API providers/routers like LiteLLM. The Authorization header was incorrectly sending a dictionary representation instead of the API key string.

**Issue**: In `openai_user.py`, `get_credentials()` returns `{"api_key": "sk-..."}` but was used directly in an f-string, resulting in:
```
Authorization: Bearer {'api_key': 'sk-...'}
```
instead of:
```
Authorization: Bearer sk-...
```

**Fix**: Use `auth_provider.get_headers()` which properly formats the Authorization header.

## PR Type / Label
/kind bug

## Related Issue
N/A - Bug discovered during manual testing with LiteLLM endpoint

## Changes
- Modified `openai_user.py`: Use `get_headers()` instead of manually constructing Authorization header
- Updated `test_openai_user.py`: Added `get_headers()` mock to test fixture

## Correctness Tests
- Updated existing unit tests in `tests/user/test_openai_user.py`
- Manually verified authentication works with LiteLLM endpoint

## Checklist
- [x] I have rebased my branch on top of the latest main branch (`git pull origin main`)
- [x] I have run `make check` to ensure code is properly formatted and passes all lint checks
- [x] I have run `make test` to verify test coverage (~90% required)
- [x] I have added tests that fail without my code changes (for bug fixes)
- [ ] I have added tests covering variants of new features (for new features)

## Additional Information
This fix ensures compatibility with any OpenAI-compatible API endpoint, not just the official OpenAI API.