### PR TITLE
[Docs] Fix github pages yml

### DIFF
--- a/docs/.config/mkdocs-gh-pages.yml
+++ b/docs/.config/mkdocs-gh-pages.yml
@@ -116,20 +116,19 @@ nav:
       - getting-started/index.md
       - Installation: getting-started/installation.md
       - Task Definition: getting-started/task-definition.md
-      - Entrypoints: getting-started/entrypoints.md
+      - CLI Guidelines: getting-started/cli-guidelines.md
       - Metrics Definition: getting-started/metrics-definition.md
+      - Migrating from SGLang/vLLM: getting-started/migrating-from-sglang-vllm.md
   - User Guide:
       - user-guide/index.md
       - Run Benchmark: user-guide/run-benchmark.md
       - Traffic Scenarios: user-guide/scenario-definition.md
       - Multi-Cloud Authentication: user-guide/multi-cloud-auth-storage.md
       - Multi-Cloud Quick Reference: user-guide/multi-cloud-quick-reference.md
-      - Docker Deployment: user-guide/run-benchmark-using-docker.md
+      - Docker Usage Guide: user-guide/run-benchmark-using-docker.md
       - Excel Reports: user-guide/generate-excel-sheet.md
       - Visualizations: user-guide/generate-plot.md
       - Upload Results: user-guide/upload-benchmark-result.md
-  - Examples:
-      - examples/index.md
   - Development:
       - development/developer-guide.md
-      - Contributing: development/contributing.md
+      - Adding New Features: development/adding-new-features.md


### PR DESCRIPTION
## Description
Fix mkdocs-gh-pages.yml to match the actual page names defined in mkdocs.yml so they show up correctly.

## PR Type / Label
<!-- 
Add one of the following:
/kind bug
/kind feature
/kind enhancement
/kind documentation
/kind ci
/kind misc
-->
/kind documentation
## Related Issue
<!-- 
Automatically closes linked issue when PR is merged.
Usage: Fixes #<issue number>, or Fixes (paste link of issue).
-->

## Changes
 - Fix mkdocs-gh-pages.yml to match the actual page names defined in mkdocs.yml so they show up correctly.

## Correctness Tests
<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

## Checklist
- [X] I have rebased my branch on top of the latest main branch (`git pull origin main`)
- [X] I have run `make check` to ensure code is properly formatted and passes all lint checks
- [X] I have run `make test` or `make test_changed` to verify test coverage (~90% required)
- [X] I have added tests that fail without my code changes (for bug fixes)
- [X] I have added tests covering variants of new features (for new features)

## Additional Information
Add any other context, screenshots, or information about the PR here.
