### PR TITLE
Revert "fix(openai): strip backend-unsupported params (e.g. ignore_eos) before send"

### DIFF
--- a/genai_bench/cli/cli.py
+++ b/genai_bench/cli/cli.py
@@ -261,7 +261,6 @@ def benchmark(
     # Set authentication and API configuration for the user class
     user_class.auth_provider = auth_provider
     user_class.host = api_base
-    user_class.api_backend = api_backend
 
     # Load the tokenizer
     tokenizer = validate_tokenizer(model_tokenizer)

--- a/genai_bench/user/openai_user.py
+++ b/genai_bench/user/openai_user.py
@@ -33,13 +33,6 @@ class OpenAIUser(BaseUser):
         # Future support can be added here
     }
 
-    # Keep this list up to date when supporting other backends
-    UNSUPPORTED_PARAMS_BY_BACKEND = {
-        "openai": {"ignore_eos"},
-        "vllm": set(),  # vLLM uses OpenAI-compatible API
-        "sglang": set(),  # SGLang uses OpenAI-compatible API
-    }
-
     host: Optional[str] = None
     auth_provider: Optional[ModelAuthProvider] = None
     headers = None
@@ -52,7 +45,6 @@ class OpenAIUser(BaseUser):
             **auth_headers,
             "Content-Type": "application/json",
         }
-        self.api_backend = getattr(self, "api_backend", self.BACKEND_NAME)
         super().on_start()
 
     @task
@@ -164,15 +156,10 @@ class OpenAIUser(BaseUser):
         response = None
 
         try:
-            backend_key = getattr(self, "api_backend", self.BACKEND_NAME)
-
-            unsupported = self.UNSUPPORTED_PARAMS_BY_BACKEND.get(backend_key, set())
-            payload_to_send = {k: v for k, v in payload.items() if k not in unsupported}
-
             start_time = time.monotonic()
             response = requests.post(
                 url=f"{self.host}{endpoint}",
-                json=payload_to_send,
+                json=payload,
                 stream=stream,
                 headers=self.headers,
             )

--- a/tests/user/test_openai_user.py
+++ b/tests/user/test_openai_user.py
@@ -95,6 +95,7 @@ def test_chat(mock_post, mock_openai_user):
             "messages": [{"role": "user", "content": ANY}],
             "max_tokens": 10,
             "temperature": 0.0,
+            "ignore_eos": False,
             "stream": True,
             "stream_options": {
                 "include_usage": True,
@@ -157,6 +158,7 @@ def test_vision(mock_post, mock_openai_user):
             "messages": [{"role": "user", "content": text_content + image_content}],
             "max_tokens": None,
             "temperature": 0.0,
+            "ignore_eos": False,
             "stream": True,
             "stream_options": {
                 "include_usage": True,


### PR DESCRIPTION
Reverts sgl-project/genai-bench#116

The PR manually copies the payload, which could be memory expensive when the payload is extreme.