### PR TITLE
feat: add options for text sampling and prefix

### DIFF
--- a/genai_bench/cli/cli.py
+++ b/genai_bench/cli/cli.py
@@ -119,6 +119,8 @@ def benchmark(
     dataset_config,
     dataset_prompt_column,
     dataset_image_column,
+    random_prompt,
+    prefix_lens,
     num_workers,
     master_port,
     spawn_rate,
@@ -297,6 +299,8 @@ def benchmark(
         data=data,
         additional_request_params=additional_request_params,
         dataset_config=dataset_config_obj,
+        random_prompt=random_prompt,
+        prefix_lens=prefix_lens,
     )
 
     # If user did not provide scenarios but provided a dataset, default to dataset mode

--- a/genai_bench/cli/option_groups.py
+++ b/genai_bench/cli/option_groups.py
@@ -12,6 +12,7 @@ from genai_bench.cli.validation import (
     validate_dataset_path_callback,
     validate_iteration_params,
     validate_object_storage_options,
+    validate_prefix_lengths_options,
     validate_task,
     validate_traffic_scenario_callback,
     validate_warmup_cooldown_ratio_options,
@@ -320,6 +321,22 @@ def sampling_options(func):
         "- Local file: /path/to/data.csv or /path/to/prompts.txt\n"
         "- HuggingFace: squad or meta-llama/Llama-2-7b-hf\n"
         "- Default: Leave empty to use built-in sonnet.txt",
+    )(func)
+    func = click.option(
+        "--random-prompt",
+        is_flag=True,
+        default=False,
+        help="Enable random prompt generation. If provided, it becomes True, and the "
+        "dataset will be sampled with prompts generated from the model's tokenizer.",
+    )(func)
+    func = click.option(
+        "--prefix-lens",
+        callback=validate_prefix_lengths_options,
+        type=str,
+        default=None,
+        help="List of prefix lengths to sample from. "
+        "If specified, the sampling prompts will be attached with a prefix "
+        "If not specified, the default is no prefix.",
     )(func)
     return func
 

--- a/genai_bench/cli/validation.py
+++ b/genai_bench/cli/validation.py
@@ -402,3 +402,18 @@ def validate_warmup_cooldown_ratio_options(ctx, param, value):
             param_hint=["--warmup-ratio", "--cooldown-ratio"],
         )
     return value
+
+
+def validate_prefix_lengths_options(ctx, param, value):
+    """Parse a comma-separated string into a list of integers."""
+    if value is None:
+        return []
+    try:
+        # Split the string by commas, strip spaces, and convert to int
+        if value.startswith("[") and value.endswith("]"):
+            value = value[1:-1]
+        return [int(x.strip()) for x in value.split(",")]
+    except ValueError as e:
+        raise click.BadParameter(
+            "Prefix lengths must be a comma-separated list of integers."
+        ) from e

--- a/tests/cli/test_cli_benchmark.py
+++ b/tests/cli/test_cli_benchmark.py
@@ -719,3 +719,79 @@ def test_spawn_rate_option_in_help(cli_runner):
     assert result.exit_code == 0
     assert "--spawn-rate" in result.output
     assert "Number of users to spawn per second" in result.output
+
+
+@pytest.mark.usefixtures(
+    "mock_env_variables",
+    "mock_dashboard",
+    "mock_validate_tokenizer",
+    "mock_time_sleep",
+    "mock_makedirs",
+    "mock_file_system",
+    "mock_report_and_plot",
+    "mock_http_requests",
+    "mock_experiment_path",
+)
+def test_benchmark_command_with_random_prompt(cli_runner, default_options):
+    """Test benchmark command with --random-prompt option."""
+    with patch("genai_bench.cli.cli.Sampler.create") as mock_sampler_create:
+        result = cli_runner.invoke(
+            benchmark,
+            [*default_options, "--traffic-scenario", "D(100,100)", "--random-prompt"],
+        )
+        assert result.exit_code == 0, f"Command failed with output: {result.output}"
+
+        # Verify that Sampler.create was called with random_prompt=True
+        mock_sampler_create.assert_called()
+        call_kwargs = mock_sampler_create.call_args[1]
+        assert "random_prompt" in call_kwargs
+        assert call_kwargs["random_prompt"] is True
+
+
+@pytest.mark.usefixtures(
+    "mock_env_variables",
+    "mock_dashboard",
+    "mock_validate_tokenizer",
+    "mock_time_sleep",
+    "mock_makedirs",
+    "mock_file_system",
+    "mock_report_and_plot",
+    "mock_http_requests",
+    "mock_experiment_path",
+)
+def test_benchmark_command_with_prefix_lens(cli_runner, default_options):
+    """Test benchmark command with --prefix-lens option."""
+    with patch("genai_bench.cli.cli.Sampler.create") as mock_sampler_create:
+        result = cli_runner.invoke(
+            benchmark,
+            [
+                *default_options,
+                "--traffic-scenario",
+                "D(100,100)",
+                "--prefix-lens",
+                "5,10,15",
+            ],
+        )
+        assert result.exit_code == 0, f"Command failed with output: {result.output}"
+
+        # Verify that Sampler.create was called with prefix_lens=[5, 10, 15]
+        mock_sampler_create.assert_called()
+        call_kwargs = mock_sampler_create.call_args[1]
+        assert "prefix_lens" in call_kwargs
+        assert call_kwargs["prefix_lens"] == [5, 10, 15]
+
+
+def test_random_prompt_option_in_help(cli_runner):
+    """Test that --random-prompt option appears in the CLI help output."""
+    result = cli_runner.invoke(benchmark, ["--help"])
+    assert result.exit_code == 0
+    assert "--random-prompt" in result.output
+    assert "Enable random prompt generation" in result.output
+
+
+def test_prefix_lens_option_in_help(cli_runner):
+    """Test that --prefix-lens option appears in the CLI help output."""
+    result = cli_runner.invoke(benchmark, ["--help"])
+    assert result.exit_code == 0
+    assert "--prefix-lens" in result.output
+    assert "List of prefix lengths to sample from" in result.output

--- a/tests/sampling/test_base.py
+++ b/tests/sampling/test_base.py
@@ -22,10 +22,20 @@ def mock_vision_dataset():
 
 def test_sampler_factory(mock_vision_dataset):
     text_data = ["Sample text 1", "Sample text 2"]
+    test_text_tokenizer = Mock()
+    # Mock tokenizer's get_vocab to some tokens with special tokens
+    test_text_tokenizer.get_vocab.return_value = {
+        "token1": 0,
+        "token2": 1,
+        "token3": 2,
+        "<special>": 3,
+        "<pad>": 4,
+        "token4": 5,
+    }
 
     sampler = Sampler.create(
         task="text-to-text",
-        tokenizer=Mock(),
+        tokenizer=test_text_tokenizer,
         model="gpt-3",
         data=text_data,
     )
@@ -33,7 +43,7 @@ def test_sampler_factory(mock_vision_dataset):
 
     sampler = Sampler.create(
         task="text-to-embeddings",
-        tokenizer=Mock(),
+        tokenizer=test_text_tokenizer,
         model="gpt-3",
         data=text_data,
     )
@@ -41,7 +51,7 @@ def test_sampler_factory(mock_vision_dataset):
 
     sampler = Sampler.create(
         task="image-text-to-text",
-        tokenizer=Mock(),
+        tokenizer=test_text_tokenizer,
         model="gpt-3",
         data=mock_vision_dataset,
     )
@@ -57,5 +67,8 @@ def test_sampler_factory(mock_vision_dataset):
 
     with pytest.raises(ValueError):
         Sampler.create(
-            task="text-to-image", tokenizer=Mock(), model="dummy-model", data=[]
+            task="text-to-image",
+            tokenizer=test_text_tokenizer,
+            model="dummy-model",
+            data=[],
         )


### PR DESCRIPTION
1. add random sampling choice
2. add prefix with lens choice for text sampling
3. add relative test case for text sampling
4. add relative test case for test_cli_benchmark

Signed-off-by:
Ziqi Huang ziqi002@linux.alibaba.com

## Description
This PR implements the prefix sampling feature and add the random text sampling mechanism.

Key functionalities include:
* Support for --prefix-lens option to generate one or more random prefix strings based on provided lengths.
* Random token sampling from the model vocabulary with filtering of special tokens.
* Updated TextSampler._sample_text to prepend generated prefixes to every prompt regardless of num_input_tokens.
* Added random sampling mode improvements, including filtered vocabulary sampling and decoding sampled token sequences.

## Related Issue
None

## Changes
* Implemented random token sampling logic: Retrieve vocabulary and filter out special tokens (those wrapped in <>). Randomly sample tokens from cleaned vocabulary. Decode sampled token sequences into a string.
* Added --prefix-lens CLI option to support generating multiple prefixes of different lengths.

## Correctness Tests
* Added unit tests covering: Random token sampling, Prefix generation, CLI benchmark command tests related to prefix and randomness options
* Overall benchmark workflow verified through print sampling propmt

## Checklist
- [x] I have rebased my branch on top of the latest main branch (`git pull origin main`)
- [x] I have run `make check` to ensure code is properly formatted and passes all lint checks
- [x] I have run `make test` or `make test_changed` to verify test coverage (~90% required)
- [x] I have added tests that fail without my code changes (for bug fixes)
- [x] I have added tests covering variants of new features (for new features)

## Additional Information
Add any other context, screenshots, or information about the PR here.
