### PR TITLE
[CI] Fix release.yml to use python instead of uv

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,12 +42,12 @@ jobs:
 
       - name: Run tests
         run: |
-          uv run --extra dev --extra multi-cloud pytest tests --cov --cov-report=term-missing -v
+          python -m pytest tests --cov --cov-report=term-missing -v
         timeout-minutes: 10
 
       - name: Check coverage threshold
         run: |
-          uv run --extra dev --extra multi-cloud coverage report --fail-under=93
+          python -m coverage report --fail-under=93
 
       # 1) version from GitHub Release tag
       - name: Extract version


### PR DESCRIPTION
## Description
<!--Please provide a brief description of the changes in this PR.-->
This PR fixes `release.yml` to use the system Python env instead of `uv run`.

`Install dependencies` already installs the env on system level. If we use `uv run`, it ignores that and uses its own locked environment.

## Changes
<!-- 
List the changes made in this PR.
-->
- Fix release.yml to use `python -m pytest` instead of uv

## Correctness Tests
<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

## Checklist
- [x] I have rebased my branch on top of the latest main branch (`git pull origin main`)
- [x] I have run `make check` to ensure code is properly formatted and passes all lint checks
- [x] I have run `make test` or `make test_changed` to verify test coverage (~90% required)
- [x] I have added tests that fail without my code changes (for bug fixes)
- [x] I have added tests covering variants of new features (for new features)
