### PR TITLE
Fix metrics filtering for non streaming tasks

### DIFF
--- a/genai_bench/metrics/aggregated_metrics_collector.py
+++ b/genai_bench/metrics/aggregated_metrics_collector.py
@@ -88,7 +88,13 @@ class AggregatedMetricsCollector:
         inference_speed = metrics.output_inference_speed
 
         # filter silently for short output latency
-        if metrics.output_latency is not None and metrics.output_latency < 0.001:
+        # Don't filter for non-streaming tasks where tpot=0 is intentional
+        # (e.g., embeddings, image generation set by _reset_output_metrics)
+        if (
+            metrics.output_latency is not None
+            and metrics.output_latency < 0.001
+            and metrics.tpot != 0
+        ):
             logger.warning(
                 f"Metric may have abnormal inference speed: "
                 f"{inference_speed} tokens/s. "


### PR DESCRIPTION
## Description
Fixed metrics filtering bug that caused non-streaming tasks (embeddings, image generation) to crash with `ValueError: No values found for metric 'tpot'`.

## Related Issue
PR #122 introduced filtering for metrics with `output_latency < 0.001s` to handle abnormal inference speeds in streaming responses. However, this incorrectly filtered non-streaming tasks where `output_latency=0` is intentional (set by `_reset_output_metrics()`), causing all `tpot` values to be set to `None` and aggregation to fail.

## Changes
Modified genai_bench/metrics/aggregated_metrics_collector.py to prevent filtering metrics when tpot=0, which is intentionally set for non-streaming tasks (embeddings, image generation) by _reset_output_metrics().


## Correctness Tests
```bash
genai-bench benchmark \
  --api-backend openai \
  --api-base https://api.openai.com \
  --api-key "<key>" \
  --api-model-name "text-embedding-ada-002" \
  --model-tokenizer "gpt2" \
  --task text-to-embeddings \
  --traffic-scenario "E(100)" \
  --max-requests-per-run 1 \
  --num-concurrency 1
```
Before fix: Crashed with ValueError: No values found for metric 'tpot'
After fix: Benchmark completes successfully, generates reports and plots without errors

---
<details>
<summary> Checklist </summary>

- [x] I have rebased my branch on top of the latest main branch (`git pull origin main`)
- [x] I have run `make check` to ensure code is properly formatted and passes all lint checks
- [x] I have run `make test` or `make test_changed` to verify test coverage (~90% required)
- [ ] I have added tests that fail without my code changes (for bug fixes)
- [ ] I have added tests covering variants of new features (for new features)

</details>