### PR TITLE
[Bugfix] Support for reasoning content for oci-genai user.

### DIFF
--- a/genai_bench/user/oci_genai_user.py
+++ b/genai_bench/user/oci_genai_user.py
@@ -275,6 +275,22 @@ class OCIGenAIUser(BaseUser):
                                 f"Text: '{text_segment}', "
                                 f"streaming events count: {streaming_events_count}"
                             )
+
+                    reasoning_segment = message.get("reasoningContent", "")
+                    if reasoning_segment:
+                        # Capture the time at the first token
+                        if not time_at_first_token:
+                            time_at_first_token = time.monotonic()
+                            logger.debug(
+                                f"First token received at: {time_at_first_token}"
+                            )
+                        generated_text += reasoning_segment
+                        streaming_events_count += 1  # each event contains one token
+                        logger.debug(
+                            f"Reasoning Text: '{reasoning_segment}', "
+                            f"streaming events count: {streaming_events_count}"
+                        )
+
                     # Track the previous data for debugging purposes
                     previous_data = parsed_data
                 else:


### PR DESCRIPTION
## Description
This PR fixes the benchmarking of reasoning models (xai, gpt-oss etc) in the oci-genai users.
   1. Reasoning tokens generated in the begining are now excluded from the TTFT and is counted as output.
   2. The fallback logic is now corrected where reasoning tokens are treated as output tokens.


## Related Issue
<!-- 
Automatically closes linked issue when PR is merged.
Usage: Fixes #<issue number>, or Fixes (paste link of issue).
-->
Fixes #154 

## Changes
<!-- 
List the changes made in this PR.
-->
- ```reasoningContent``` is now read and returned as part of each streaming event.

## Correctness Tests
<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

Please look at the metrics before and after the change:

### Before

| Use Case                            | Concurrency | TTFT (s) | Output Inference Speed per Request (tokens/s) | Output Throughput of Server (tokens/s) | End-to-End Latency per Request (s) |
|-------------------------------------|-------------|----------|-----------------------------------------------|----------------------------------------|------------------------------------|
| Scenario 4: Typical RAG D(2000,200) | 1           | 5.17     | 928.79                                        | 13.25                                  | 5.41                               |


### After

| Use Case                            | Concurrency | TTFT (s) | Output Inference Speed per Request (tokens/s) | Output Throughput of Server (tokens/s) | End-to-End Latency per Request (s) |
|-------------------------------------|-------------|----------|-----------------------------------------------|----------------------------------------|------------------------------------|
| Scenario 4: Typical RAG D(2000,200) | 1           | 3.90     | 136.91                                        | 36.40                                  | 5.38                               |


---




<details>
<summary> Checklist </summary>

- [x] I have rebased my branch on top of the latest main branch (`git pull origin main`)
- [x] I have run `make check` to ensure code is properly formatted and passes all lint checks
- [x] I have run `make test` or `make test_changed` to verify test coverage (~90% required)
- [x] I have added tests that fail without my code changes (for bug fixes)
- [x] I have added tests covering variants of new features (for new features)

</details>