### PR TITLE
fix: improve vague "Invalid Response" error message in openai_user.py

### DIFF
--- a/genai_bench/user/openai_user.py
+++ b/genai_bench/user/openai_user.py
@@ -308,7 +308,18 @@ class OpenAIUser(BaseUser):
                         )
                         time_at_first_token = time.monotonic()
                     else:
-                        raise Exception("Invalid Response")
+                        raise Exception(
+                            "Invalid streaming response: "
+                            "received final usage chunk "
+                            "with completion_tokens="
+                            f"{tokens_received}, but no "
+                            "content was delivered during "
+                            "streaming (time_at_first_token"
+                            " was never set). This typically"
+                            " means the model returned an "
+                            "empty response. Raw usage "
+                            f"data: {data.get('usage')}"
+                        )
                 break
 
             try:


### PR DESCRIPTION
## Description
Improve the generic "Invalid Response" exception in `parse_chat_response` to provide actionable diagnostic information for debugging.

## Related Issue
N/A

## Changes
- Replaced the vague `raise Exception("Invalid Response")` with a descriptive message that includes:
  - The `completion_tokens` count from the usage chunk
  - Context that `time_at_first_token` was never set (no content delivered during streaming)
  - The likely cause (model returned an empty response)
  - The raw `usage` data from the response for debugging

## Correctness Tests
- This is a string-only change to an error message; no logic is altered.
- `make check` passes (format, lint, mypy).

---
<details>
<summary> Checklist </summary>

- [x] I have rebased my branch on top of the latest main branch (`git pull origin main`)
- [x] I have run `make check` to ensure code is properly formatted and passes all lint checks
- [ ] I have run `make test` or `make test_changed` to verify test coverage (~90% required)
- [ ] I have added tests that fail without my code changes (for bug fixes)
- [ ] I have added tests covering variants of new features (for new features)

</details>