### PR TITLE
Prefer server-reported prompt tokens over local tokenizer estimate

### DIFF
--- a/genai_bench/user/azure_openai_user.py
+++ b/genai_bench/user/azure_openai_user.py
@@ -335,13 +335,13 @@ class AzureOpenAIUser(BaseUser):
 
     @staticmethod
     def _get_usage_info(data, num_prefill_tokens):
-        num_prompt_tokens = data["usage"]["prompt_tokens"]
-        tokens_received = data["usage"]["completion_tokens"]
-        # For vision task
-        if num_prefill_tokens is None:
-            # use num_prompt_tokens as prefill to cover image tokens
-            num_prefill_tokens = num_prompt_tokens
-        if abs(num_prompt_tokens - num_prefill_tokens) >= 50:
+        num_prompt_tokens = data["usage"].get("prompt_tokens")
+        tokens_received = data["usage"].get("completion_tokens", 0)
+        if (
+            num_prompt_tokens is not None
+            and num_prefill_tokens is not None
+            and abs(num_prompt_tokens - num_prefill_tokens) >= 50
+        ):
             logger.warning(
                 f"Significant difference detected in prompt tokens: "
                 f"The number of prompt tokens processed by the model "
@@ -350,7 +350,11 @@ class AzureOpenAIUser(BaseUser):
                 f"({num_prefill_tokens}) by "
                 f"{abs(num_prompt_tokens - num_prefill_tokens)} tokens."
             )
-        return num_prefill_tokens, num_prompt_tokens, tokens_received
+        # Prefer server-reported prompt token count, fall back to local estimate
+        effective_prefill = (
+            num_prompt_tokens if num_prompt_tokens is not None else num_prefill_tokens
+        )
+        return effective_prefill, num_prompt_tokens, tokens_received
 
     @staticmethod
     def parse_embedding_response(

--- a/genai_bench/user/cohere_user.py
+++ b/genai_bench/user/cohere_user.py
@@ -258,6 +258,8 @@ class CohereUser(BaseUser):
                                 f"({num_prefill_tokens}) by "
                                 f"{abs(num_input_tokens - num_prefill_tokens)} tokens."
                             )
+                        # Prefer server-reported input token count
+                        num_prefill_tokens = num_input_tokens
 
             except json.JSONDecodeError:
                 logger.warning(f"Failed to decode JSON line: {output_line}")

--- a/genai_bench/user/openai_user.py
+++ b/genai_bench/user/openai_user.py
@@ -391,13 +391,13 @@ class OpenAIUser(BaseUser):
 
     @staticmethod
     def _get_usage_info(data, num_prefill_tokens):
-        num_prompt_tokens = data["usage"]["prompt_tokens"]
-        tokens_received = data["usage"]["completion_tokens"]
-        # For vision task
-        if num_prefill_tokens is None:
-            # use num_prompt_tokens as prefill to cover image tokens
-            num_prefill_tokens = num_prompt_tokens
-        if abs(num_prompt_tokens - num_prefill_tokens) >= 50:
+        num_prompt_tokens = data["usage"].get("prompt_tokens")
+        tokens_received = data["usage"].get("completion_tokens", 0)
+        if (
+            num_prompt_tokens is not None
+            and num_prefill_tokens is not None
+            and abs(num_prompt_tokens - num_prefill_tokens) >= 50
+        ):
             logger.warning(
                 f"Significant difference detected in prompt tokens: "
                 f"The number of prompt tokens processed by the model "
@@ -406,7 +406,11 @@ class OpenAIUser(BaseUser):
                 f"({num_prefill_tokens}) by "
                 f"{abs(num_prompt_tokens - num_prefill_tokens)} tokens."
             )
-        return num_prefill_tokens, num_prompt_tokens, tokens_received
+        # Prefer server-reported prompt token count, fall back to local estimate
+        effective_prefill = (
+            num_prompt_tokens if num_prompt_tokens is not None else num_prefill_tokens
+        )
+        return effective_prefill, num_prompt_tokens, tokens_received
 
     @staticmethod
     def parse_embedding_response(

--- a/genai_bench/user/together_user.py
+++ b/genai_bench/user/together_user.py
@@ -346,13 +346,13 @@ class TogetherUser(BaseUser):
 
     @staticmethod
     def _get_usage_info(data, num_prefill_tokens):
-        num_prompt_tokens = data["usage"]["prompt_tokens"]
-        tokens_received = data["usage"]["completion_tokens"]
-        # For vision task
-        if num_prefill_tokens is None:
-            # use num_prompt_tokens as prefill to cover image tokens
-            num_prefill_tokens = num_prompt_tokens
-        if abs(num_prompt_tokens - num_prefill_tokens) >= 50:
+        num_prompt_tokens = data["usage"].get("prompt_tokens")
+        tokens_received = data["usage"].get("completion_tokens", 0)
+        if (
+            num_prompt_tokens is not None
+            and num_prefill_tokens is not None
+            and abs(num_prompt_tokens - num_prefill_tokens) >= 50
+        ):
             logger.warning(
                 f"Significant difference detected in prompt tokens: "
                 f"The number of prompt tokens processed by the model "
@@ -361,7 +361,11 @@ class TogetherUser(BaseUser):
                 f"({num_prefill_tokens}) by "
                 f"{abs(num_prompt_tokens - num_prefill_tokens)} tokens."
             )
-        return num_prefill_tokens, num_prompt_tokens, tokens_received
+        # Prefer server-reported prompt token count, fall back to local estimate
+        effective_prefill = (
+            num_prompt_tokens if num_prompt_tokens is not None else num_prefill_tokens
+        )
+        return effective_prefill, num_prompt_tokens, tokens_received
 
     @staticmethod
     def parse_embedding_response(

--- a/tests/user/test_cohere_user.py
+++ b/tests/user/test_cohere_user.py
@@ -100,7 +100,7 @@ def test_chat_success(cohere_user, mock_response):
         assert response.status_code == 200
         assert response.generated_text == "Hello world"
         assert response.tokens_received == 22
-        assert response.num_prefill_tokens == 5
+        assert response.num_prefill_tokens == 68  # Prefers server-reported input tokens
         assert response.time_at_first_token is not None
 
 

--- a/tests/user/test_openai_user.py
+++ b/tests/user/test_openai_user.py
@@ -305,7 +305,7 @@ def test_send_request_chat_response(mock_post, mock_openai_user):
     assert isinstance(user_response, UserChatResponse)
     assert user_response.status_code == 200
     assert user_response.tokens_received == 5
-    assert user_response.num_prefill_tokens == 5
+    assert user_response.num_prefill_tokens == 6421  # Prefers server-reported prompt tokens
     assert user_response.generated_text == "The image depicts a serene"
     mock_post.assert_called_once()
 

--- a/tests/user/test_together_user.py
+++ b/tests/user/test_together_user.py
@@ -307,7 +307,7 @@ def test_send_request_chat_response(mock_post, mock_together_user):
     assert isinstance(user_response, UserChatResponse)
     assert user_response.status_code == 200
     assert user_response.tokens_received == 5
-    assert user_response.num_prefill_tokens == 5
+    assert user_response.num_prefill_tokens == 6421  # Prefers server-reported prompt tokens
     assert user_response.generated_text == "The image depicts a serene"
     mock_post.assert_called_once()
 


### PR DESCRIPTION
I've discovered that when server-side and local-side token counts differ, the local one is actually used for metrics. I'm wondering if that's intended and if yes, what's the use case?

I have an interesting use case that's currently not supported by GenAI Bench where I have a different system message for every prompt and I need to modify the user class. I pass a stringified messages array as the prompt, then deserialize it in a custom user class and send the structured messages to the server. The issue is that the number of input tokens is taken from the local tokenizer, which actually tokenizes the raw JSON string instead of what the server sees (the deserialized chat messages). This causes large discrepancies in `input_throughput` and `num_input_tokens` metrics.

This PR makes `_get_usage_info` prefer the server-reported `prompt_tokens` when available, falling back to the local tokenizer estimate when the server doesn't return usage info.

**Note:** Input token counts will increase compared to previous runs because the server-reported count includes special tokens (BOS, role headers, EOT, etc.) from the chat template, whereas the local tokenizer was counting with `add_special_tokens=False`. This is the correct count — it reflects what the server actually processed.

## Related Issue

N/A

## Changes

- `_get_usage_info` in `openai_user.py`, `together_user.py`, `azure_openai_user.py`: return server-reported `prompt_tokens` when available, fall back to local `num_prefill_tokens` when not
- `cohere_user.py`: update `num_prefill_tokens` with server-reported `input_tokens` (was previously read but discarded)
- `test_azure_openai_user.py`: updated existing assertion + added tests for server-preferred, fallback, and both-none cases

## Correctness Tests

- `test_get_usage_info_prefers_server_tokens` — server returns prompt_tokens, local differs → server value used
- `test_get_usage_info_falls_back_to_local_when_server_missing` — server doesn't return prompt_tokens → local estimate used
- `test_get_usage_info_both_none` — neither server nor local available → returns None
- Existing vision and warning tests continue to pass

---
<details>
<summary> Checklist </summary>

- [x] I have rebased my branch on top of the latest main branch (`git pull origin main`)
- [x] I have run `make check` to ensure code is properly formatted and passes all lint checks
- [x] I have run `make test` or `make test_changed` to verify test coverage (~90% required)
- [x] I have added tests that fail without my code changes (for bug fixes)
- [ ] I have added tests covering variants of new features (for new features)

</details>