### PR TITLE
[Core] Update OCI users to report reasoning

### DIFF
--- a/genai_bench/user/oci_cohere_user.py
+++ b/genai_bench/user/oci_cohere_user.py
@@ -375,6 +375,7 @@ class OCICohereUser(BaseUser):
             status_code=200,
             generated_text=generated_text,
             tokens_received=tokens_received,
+            reasoning_tokens=0,  # OCI Cohere v1 API does not support reasoning
             time_at_first_token=time_at_first_token,
             num_prefill_tokens=num_prefill_tokens,
             start_time=start_time,

--- a/genai_bench/user/oci_genai_user.py
+++ b/genai_bench/user/oci_genai_user.py
@@ -236,6 +236,7 @@ class OCIGenAIUser(BaseUser):
         """
         generated_text = ""
         streaming_events_count = 0
+        reasoning_streaming_events_count = 0
         total_tokens = None
         prompt_tokens = None
         time_at_first_token: Optional[float] = None
@@ -288,9 +289,12 @@ class OCIGenAIUser(BaseUser):
                             )
                         generated_text += reasoning_segment
                         streaming_events_count += 1  # each event contains one token
+                        reasoning_streaming_events_count += 1  # count reasoning tokens
                         logger.debug(
                             f"Reasoning Text: '{reasoning_segment}', "
-                            f"streaming events count: {streaming_events_count}"
+                            f"streaming events count: {streaming_events_count}, "
+                            "reasoning events count: "
+                            f"{reasoning_streaming_events_count}"
                         )
 
                     # Track the previous data for debugging purposes
@@ -335,6 +339,7 @@ class OCIGenAIUser(BaseUser):
             f"Time at first token: {time_at_first_token} \n"
             f"Finish reason: {finish_reason}\n"
             f"Streaming Events Count: {streaming_events_count}\n"
+            f"Reasoning Streaming Events Count: {reasoning_streaming_events_count}\n"
             f"Total Tokens (from usage): {total_tokens}\n"
             f"Prompt Tokens (from usage): {prompt_tokens}\n"
             f"Usage data: {usage_data}\n"
@@ -352,6 +357,7 @@ class OCIGenAIUser(BaseUser):
             status_code=200,
             generated_text=generated_text,
             tokens_received=tokens_received,
+            reasoning_tokens=reasoning_streaming_events_count,  # reasoning tokens count
             time_at_first_token=time_at_first_token,
             num_prefill_tokens=num_prefill_tokens,
             start_time=start_time,

--- a/tests/user/test_oci_cohere_user.py
+++ b/tests/user/test_oci_cohere_user.py
@@ -98,6 +98,7 @@ def test_chat(mock_client_class, test_cohere_user):
     user_response = args[0]
     assert user_response.status_code == 200
     assert user_response.num_prefill_tokens == 5
+    assert user_response.reasoning_tokens == 0
 
 
 @patch("genai_bench.user.oci_cohere_user.GenerativeAiInferenceClient")


### PR DESCRIPTION
## Description
Build on reasoning token API changes in https://github.com/sgl-project/genai-bench/pull/172#pullrequestreview-3793933129 . Update oci_genai_user to support reasoning tokens. Also update oci_cohere_user to explicitly report 0 reasoning tokens, as the v1 OCI Cohere API does not support reasoning. 

## Related Issue
https://github.com/sgl-project/genai-bench/issues/162


## Changes
oci_cohere_user.py:
 - OCI Cohere v1 API does not support reasoning. v2 API (for command A reasoning) does but is not currently implemented in Genai-bench. Always report 0 reasoning tokens.
oci_genai_user.py:
 - Track new variable `reasoning_streaming_events_count`, since OCI returns chunks one token at a time.
 - Increment `reasoning_streaming_events_count` if a reasoning segment is received. Return the value as `reasoning_tokens`.

Updated test_oci_genai_user.py and test_oci_cohere_user.py.



## Correctness Tests
<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

---
<details>
<summary> Checklist </summary>

- [X] I have rebased my branch on top of the latest main branch (`git pull origin main`)
- [X] I have run `make check` to ensure code is properly formatted and passes all lint checks
- [X] I have run `make test` or `make test_changed` to verify test coverage (~90% required)
- [X] I have added tests that fail without my code changes (for bug fixes)
- [X] I have added tests covering variants of new features (for new features)

</details>