### PR TITLE
feat: add audio-to-text task for speech transcription benchmarking

### DIFF
--- a/genai_bench/analysis/plot_config.py
+++ b/genai_bench/analysis/plot_config.py
@@ -328,6 +328,47 @@ class PlotConfigManager:
                 },
             ],
         },
+        "audio_to_text": {
+            "layout": {"rows": 2, "cols": 2, "figsize": [20, 12]},
+            "plots": [
+                {
+                    "title": "Avg Latency per Sample vs Processed Audio Throughput",
+                    "x_field": "mean_input_throughput_tokens_per_s",
+                    "y_field": "stats.e2e_latency.mean",
+                    "x_label": "Processed Audio Length (audio-cs/s)",
+                    "y_label": "Avg Latency per Sample (s)",
+                    "plot_type": "line",
+                    "position": [0, 0],
+                },
+                {
+                    "title": "Real-Time Factor Mean vs Processed Audio Throughput",
+                    "x_field": "mean_input_throughput_tokens_per_s",
+                    "y_field": "stats.output_inference_speed.mean",
+                    "x_label": "Processed Audio Length (audio-cs/s)",
+                    "y_label": "Real-Time Factor mean",
+                    "plot_type": "line",
+                    "position": [0, 1],
+                },
+                {
+                    "title": "Real-Time Factor P99 vs Processed Audio Throughput",
+                    "x_field": "mean_input_throughput_tokens_per_s",
+                    "y_field": "stats.output_inference_speed.p99",
+                    "x_label": "Processed Audio Length (audio-cs/s)",
+                    "y_label": "Real-Time Factor P99",
+                    "plot_type": "line",
+                    "position": [1, 0],
+                },
+                {
+                    "title": "Error Rates by HTTP Status vs Concurrency",
+                    "x_field": "num_concurrency",
+                    "y_field": "error_rate",
+                    "x_label": "Concurrency",
+                    "y_label": "Error Rate",
+                    "plot_type": "bar",
+                    "position": [1, 1],
+                },
+            ],
+        },
         "single_scenario_analysis": {
             "layout": {"rows": 2, "cols": 2, "figsize": [16, 12]},
             "plots": [

--- a/genai_bench/cli/cli.py
+++ b/genai_bench/cli/cli.py
@@ -12,6 +12,7 @@ import gevent
 from genai_bench.analysis.excel_report import create_workbook
 from genai_bench.analysis.experiment_loader import load_one_experiment
 from genai_bench.analysis.flexible_plot_report import plot_experiment_data_flexible
+from genai_bench.analysis.plot_config import PlotConfigManager
 from genai_bench.analysis.plot_report import (
     plot_single_scenario_inference_speed_vs_throughput,
 )
@@ -546,6 +547,11 @@ def benchmark(
         percentile="mean",
         metrics_time_unit=metrics_time_unit,
     )
+    plot_config = (
+        PlotConfigManager.load_preset("audio_to_text", metrics_time_unit)
+        if task == "audio-to-text"
+        else None
+    )
     plot_experiment_data_flexible(
         [
             (experiment_metadata, run_data),
@@ -553,6 +559,7 @@ def benchmark(
         group_key="traffic_scenario",
         experiment_folder=experiment_folder_abs_path,
         metrics_time_unit=metrics_time_unit,
+        plot_config=plot_config,
     )
     logger.info(
         f"📁 Please check {experiment_folder_abs_path} "

--- a/genai_bench/cli/option_groups.py
+++ b/genai_bench/cli/option_groups.py
@@ -48,6 +48,7 @@ def api_options(func):
                 "text-to-rerank",
                 "image-text-to-text",
                 "image-to-embeddings",
+                "audio-to-text",
             ],
             case_sensitive=False,
         ),

--- a/genai_bench/cli/validation.py
+++ b/genai_bench/cli/validation.py
@@ -84,7 +84,7 @@ DEFAULT_SCENARIOS_BY_TASK = {
     "image-text-to-text": DEFAULT_SCENARIOS_FOR_VISION,
     "text-to-embeddings": DEFAULT_SCENARIOS_FOR_EMBEDDING,
     "image-to-embeddings": DEFAULT_SCENARIOS_FOR_VISION,
-    "audio-to-text": ["dataset"],
+    "audio-to-text": ["A(10,5)", "A(30,15)", "A(60,30)", "A(120,60)"],
     # add other tasks and default scenarios as needed
 }
 

--- a/genai_bench/cli/validation.py
+++ b/genai_bench/cli/validation.py
@@ -84,6 +84,7 @@ DEFAULT_SCENARIOS_BY_TASK = {
     "image-text-to-text": DEFAULT_SCENARIOS_FOR_VISION,
     "text-to-embeddings": DEFAULT_SCENARIOS_FOR_EMBEDDING,
     "image-to-embeddings": DEFAULT_SCENARIOS_FOR_VISION,
+    "audio-to-text": ["dataset"],
     # add other tasks and default scenarios as needed
 }
 
@@ -113,6 +114,11 @@ def validate_dataset_path_callback(ctx, param, value):
                 "Using dataset configuration file for image task. "
                 "Ensure your config file specifies the correct image dataset source."
             )
+    if input_modality == "audio" and value is None:
+        raise click.BadParameter(
+            "--dataset-path is required for audio-to-text task. "
+            "Provide a text file listing one audio file path per line."
+        )
     return value
 
 

--- a/genai_bench/data/loaders/audio.py
+++ b/genai_bench/data/loaders/audio.py
@@ -1,0 +1,75 @@
+"""Dataset loader for audio files used in audio-to-text benchmarking."""
+
+import io
+import struct
+import wave
+from pathlib import Path
+from typing import Any, List, Set, Tuple
+
+from genai_bench.data.loaders.base import DatasetFormat, DatasetLoader
+from genai_bench.logging import init_logger
+
+logger = init_logger(__name__)
+
+
+class AudioDatasetLoader(DatasetLoader):
+    """
+    Loads audio files from a local file path for audio-to-text benchmarking.
+
+    Supported source: local file only (wav, mp3, flac, m4a).
+
+    Returns a list of (audio_bytes, duration_s, filename) tuples.
+    """
+
+    supported_formats: Set[DatasetFormat] = {
+        DatasetFormat.TEXT,  # reuse TEXT format enum for local file paths
+    }
+    media_type = "Audio"
+
+    # Supported audio extensions
+    AUDIO_EXTENSIONS = {".wav", ".mp3", ".flac", ".m4a", ".ogg", ".webm"}
+
+    def _process_loaded_data(self, data: Any) -> List[Tuple[bytes, float, str]]:
+        """Process loaded data into (audio_bytes, duration_s, filename) tuples."""
+        # data from file source is a list of strings (file paths)
+        if not isinstance(data, list):
+            raise ValueError(
+                f"AudioDatasetLoader expected a list of file paths, got {type(data)}"
+            )
+
+        results = []
+        for item in data:
+            path = Path(item.strip())
+            if not path.exists():
+                logger.warning("Audio file not found, skipping: %s", path)
+                continue
+            if path.suffix.lower() not in self.AUDIO_EXTENSIONS:
+                logger.warning(
+                    "Unsupported audio extension '%s', skipping: %s",
+                    path.suffix,
+                    path,
+                )
+                continue
+            audio_bytes = path.read_bytes()
+            duration_s = (
+                _get_wav_duration(audio_bytes)
+                if path.suffix.lower() == ".wav"
+                else None
+            )
+            results.append((audio_bytes, duration_s, path.name))
+
+        if not results:
+            raise ValueError(
+                "No valid audio files found. "
+                "Provide a text file listing one audio file path per line."
+            )
+        return results
+
+
+def _get_wav_duration(audio_bytes: bytes) -> float:
+    """Return duration in seconds for a WAV file, or 0.0 on parse error."""
+    try:
+        with wave.open(io.BytesIO(audio_bytes)) as wf:
+            return wf.getnframes() / wf.getframerate()
+    except (wave.Error, struct.error, EOFError):
+        return 0.0

--- a/genai_bench/data/loaders/audio.py
+++ b/genai_bench/data/loaders/audio.py
@@ -4,7 +4,7 @@ import io
 import struct
 import wave
 from pathlib import Path
-from typing import Any, List, Set, Tuple
+from typing import Any, List, Optional, Set, Tuple
 
 from genai_bench.data.loaders.base import DatasetFormat, DatasetLoader
 from genai_bench.logging import init_logger
@@ -51,11 +51,7 @@ class AudioDatasetLoader(DatasetLoader):
                 )
                 continue
             audio_bytes = path.read_bytes()
-            duration_s = (
-                _get_wav_duration(audio_bytes)
-                if path.suffix.lower() == ".wav"
-                else None
-            )
+            duration_s = _get_audio_duration(audio_bytes, path.suffix.lower())
             results.append((audio_bytes, duration_s, path.name))
 
         if not results:
@@ -66,10 +62,16 @@ class AudioDatasetLoader(DatasetLoader):
         return results
 
 
-def _get_wav_duration(audio_bytes: bytes) -> float:
-    """Return duration in seconds for a WAV file, or 0.0 on parse error."""
+def _get_audio_duration(audio_bytes: bytes, suffix: str) -> Optional[float]:
+    """Return duration in seconds for an audio file, or None on parse error."""
     try:
-        with wave.open(io.BytesIO(audio_bytes)) as wf:
-            return wf.getnframes() / wf.getframerate()
-    except (wave.Error, struct.error, EOFError):
-        return 0.0
+        if suffix == ".wav":
+            with wave.open(io.BytesIO(audio_bytes)) as wf:
+                return wf.getnframes() / wf.getframerate()
+        else:
+            import soundfile as sf
+
+            with sf.SoundFile(io.BytesIO(audio_bytes)) as f:
+                return f.frames / f.samplerate
+    except Exception:
+        return None

--- a/genai_bench/data/loaders/base.py
+++ b/genai_bench/data/loaders/base.py
@@ -64,7 +64,7 @@ class DatasetLoader(ABC):
                     f"{self.media_type} loader."
                 )
 
-    def load_request(self) -> Union[List[str], List[Tuple[str, Any]]]:
+    def load_request(self) -> Union[List[str], List[Tuple[Any, ...]]]:
         """Load data from the dataset source."""
         self._disable_pillow_decompresion_check()
         data = self.dataset_source.load()
@@ -73,7 +73,7 @@ class DatasetLoader(ABC):
     @abstractmethod
     def _process_loaded_data(
         self, data: Any
-    ) -> Union[List[str], List[Tuple[str, Any]]]:
+    ) -> Union[List[str], List[Tuple[Any, ...]]]:
         """
         Process data loaded from dataset source. Must be implemented by subclasses.
         """

--- a/genai_bench/data/loaders/factory.py
+++ b/genai_bench/data/loaders/factory.py
@@ -3,6 +3,7 @@
 from typing import Any, List, Tuple, Union, cast
 
 from genai_bench.data.config import DatasetConfig
+from genai_bench.data.loaders.audio import AudioDatasetLoader
 from genai_bench.data.loaders.image import ImageDatasetLoader
 from genai_bench.data.loaders.text import TextDatasetLoader
 from genai_bench.logging import init_logger
@@ -16,7 +17,7 @@ class DataLoaderFactory:
     @staticmethod
     def load_data_for_task(
         task: str, dataset_config: DatasetConfig
-    ) -> Union[List[str], List[Tuple[str, Any]]]:
+    ) -> Union[List[str], List[Tuple[Any, ...]]]:
         """Load data for a specific task.
 
         Args:
@@ -32,6 +33,8 @@ class DataLoaderFactory:
             return DataLoaderFactory._load_text_data(dataset_config, output_modality)
         elif "image" in input_modality:
             return DataLoaderFactory._load_image_data(dataset_config)
+        elif input_modality == "audio":
+            return DataLoaderFactory._load_audio_data(dataset_config)
         else:
             raise ValueError(f"Unsupported input modality: {input_modality}")
 
@@ -54,5 +57,14 @@ class DataLoaderFactory:
     ) -> List[Tuple[str, Any]]:
         """Load image data."""
         loader = ImageDatasetLoader(dataset_config)
+        data = loader.load_request()
+        return data  # type: ignore
+
+    @staticmethod
+    def _load_audio_data(
+        dataset_config: DatasetConfig,
+    ) -> List[Tuple[Any, ...]]:
+        """Load audio data as (audio_bytes, duration_s, filename) tuples."""
+        loader = AudioDatasetLoader(dataset_config)
         data = loader.load_request()
         return data  # type: ignore

--- a/genai_bench/metrics/request_metrics_collector.py
+++ b/genai_bench/metrics/request_metrics_collector.py
@@ -97,9 +97,7 @@ class RequestMetricsCollector:
                 f" your server and request!"
             )
 
-    def _calculate_audio_output_metrics(
-        self, response: UserAudioTranscriptionResponse
-    ):
+    def _calculate_audio_output_metrics(self, response: UserAudioTranscriptionResponse):
         """
         Helper function to calculate output metrics for audio transcription.
 

--- a/genai_bench/metrics/request_metrics_collector.py
+++ b/genai_bench/metrics/request_metrics_collector.py
@@ -101,8 +101,17 @@ class RequestMetricsCollector:
         """
         Helper function to calculate output metrics for audio transcription.
 
-        Uses transcribed character count as a proxy for output tokens, so that
-        throughput and speed plots are populated meaningfully rather than all-zero.
+        - output_inference_speed stores Real-Time Factor (RTF):
+            RTF = audio_duration_s / e2e_latency
+          Higher RTF = faster than real-time. This matches Ming's benchmark graphs.
+        - num_prefill_tokens (set in parse_transcription_response) stores
+          audio duration in centiseconds (1 audio-s = 100 units), so
+          mean_input_throughput_tokens_per_s = audio centiseconds processed per
+          wall second. Divide by 100 to convert to audio-seconds/wall-second.
+        - output_throughput stores audio-seconds/wall-second (RTF equivalent
+          at the server level), computed as sum(audio_duration_s) / run_duration
+          via num_input_tokens sum / 100 / run_duration — but here we store the
+          per-request value for aggregation.
         """
         char_count = len(response.transcribed_text or "")
         self.metrics.num_output_tokens = char_count
@@ -110,18 +119,17 @@ class RequestMetricsCollector:
         self.metrics.total_tokens += char_count
         self.metrics.output_latency = self.metrics.e2e_latency
 
-        if char_count > 1:
-            self.metrics.tpot = self.metrics.output_latency / (char_count - 1)
-            self.metrics.output_inference_speed = 1 / self.metrics.tpot
-            self.metrics.output_throughput = (
-                (char_count - 1) / self.metrics.output_latency
-                if self.metrics.output_latency
-                else 0
-            )
+        # Real-Time Factor: how many seconds of audio processed per second of wall time
+        audio_duration_s = response.audio_duration_s or 0.0
+        if self.metrics.e2e_latency and self.metrics.e2e_latency > 0:
+            rtf = audio_duration_s / self.metrics.e2e_latency
         else:
-            self.metrics.tpot = 0
-            self.metrics.output_inference_speed = 0
-            self.metrics.output_throughput = 0
+            rtf = 0.0
+
+        self.metrics.output_inference_speed = rtf
+        # tpot and output_throughput are not meaningful for audio; set to 0
+        self.metrics.tpot = 0
+        self.metrics.output_throughput = 0
 
     def _reset_output_metrics(self):
         """Helper function to reset all output-related metrics to 0."""

--- a/genai_bench/metrics/request_metrics_collector.py
+++ b/genai_bench/metrics/request_metrics_collector.py
@@ -1,6 +1,7 @@
 from genai_bench.logging import init_logger
 from genai_bench.metrics.metrics import RequestLevelMetrics
 from genai_bench.protocol import (
+    UserAudioTranscriptionResponse,
     UserChatResponse,
     UserImageGenerationResponse,
     UserResponse,
@@ -32,12 +33,12 @@ class RequestMetricsCollector:
             response (UserResponse): The customized UserResponse object
                 containing the response data needed to calculate metrics.
         """
-        assert response.num_prefill_tokens is not None, (
-            "response.num_prefill_tokens is None"
-        )
-        assert response.time_at_first_token is not None, (
-            "response.time_at_first_token is None"
-        )
+        assert (
+            response.num_prefill_tokens is not None
+        ), "response.num_prefill_tokens is None"
+        assert (
+            response.time_at_first_token is not None
+        ), "response.time_at_first_token is None"
         assert response.start_time is not None, "response.start_time is None"
         assert response.end_time is not None, "response.end_time is None"
 
@@ -57,6 +58,8 @@ class RequestMetricsCollector:
         # Check if the response is a UserChatResponse for output metrics
         if isinstance(response, UserChatResponse):
             self._calculate_output_metrics(response)
+        elif isinstance(response, UserAudioTranscriptionResponse):
+            self._calculate_audio_output_metrics(response)
         elif isinstance(response, UserImageGenerationResponse):
             # For image generation (non-streaming), use same approach as embeddings
             # to avoid filter_metrics setting tpot/output_inference_speed to None
@@ -93,6 +96,34 @@ class RequestMetricsCollector:
                 f"{self.metrics.num_output_tokens} is <= 1. Please check"
                 f" your server and request!"
             )
+
+    def _calculate_audio_output_metrics(
+        self, response: UserAudioTranscriptionResponse
+    ):
+        """
+        Helper function to calculate output metrics for audio transcription.
+
+        Uses transcribed character count as a proxy for output tokens, so that
+        throughput and speed plots are populated meaningfully rather than all-zero.
+        """
+        char_count = len(response.transcribed_text or "")
+        self.metrics.num_output_tokens = char_count
+        self.metrics.num_reasoning_tokens = 0
+        self.metrics.total_tokens += char_count
+        self.metrics.output_latency = self.metrics.e2e_latency
+
+        if char_count > 1:
+            self.metrics.tpot = self.metrics.output_latency / (char_count - 1)
+            self.metrics.output_inference_speed = 1 / self.metrics.tpot
+            self.metrics.output_throughput = (
+                (char_count - 1) / self.metrics.output_latency
+                if self.metrics.output_latency
+                else 0
+            )
+        else:
+            self.metrics.tpot = 0
+            self.metrics.output_inference_speed = 0
+            self.metrics.output_throughput = 0
 
     def _reset_output_metrics(self):
         """Helper function to reset all output-related metrics to 0."""

--- a/genai_bench/metrics/request_metrics_collector.py
+++ b/genai_bench/metrics/request_metrics_collector.py
@@ -113,23 +113,31 @@ class RequestMetricsCollector:
           via num_input_tokens sum / 100 / run_duration — but here we store the
           per-request value for aggregation.
         """
-        char_count = len(response.transcribed_text or "")
-        self.metrics.num_output_tokens = char_count
+        token_count = response.tokens_received or 0
+        self.metrics.num_output_tokens = token_count
         self.metrics.num_reasoning_tokens = 0
-        self.metrics.total_tokens += char_count
+        self.metrics.total_tokens += token_count
         self.metrics.output_latency = self.metrics.e2e_latency
 
-        # Real-Time Factor: how many seconds of audio processed per second of wall time
+        # Real-Time Factor: audio seconds processed per wall second
         audio_duration_s = response.audio_duration_s or 0.0
         if self.metrics.e2e_latency and self.metrics.e2e_latency > 0:
             rtf = audio_duration_s / self.metrics.e2e_latency
         else:
             rtf = 0.0
-
         self.metrics.output_inference_speed = rtf
-        # tpot and output_throughput are not meaningful for audio; set to 0
-        self.metrics.tpot = 0
-        self.metrics.output_throughput = 0
+
+        # TPOT and output throughput from real token counts
+        if token_count > 1:
+            self.metrics.tpot = self.metrics.output_latency / (token_count - 1)
+            self.metrics.output_throughput = (
+                (token_count - 1) / self.metrics.output_latency
+                if self.metrics.output_latency
+                else 0
+            )
+        else:
+            self.metrics.tpot = 0
+            self.metrics.output_throughput = 0
 
     def _reset_output_metrics(self):
         """Helper function to reset all output-related metrics to 0."""

--- a/genai_bench/protocol.py
+++ b/genai_bench/protocol.py
@@ -218,6 +218,10 @@ class UserAudioTranscriptionResponse(UserResponse):
         default=None,
         description="Duration of the audio processed, in seconds.",
     )
+    tokens_received: Optional[int] = Field(
+        default=None,
+        description="Number of output tokens in the transcription.",
+    )
 
 
 class APIAuthConfig(BaseModel):

--- a/genai_bench/protocol.py
+++ b/genai_bench/protocol.py
@@ -115,6 +115,29 @@ class UserImageGenerationRequest(UserRequest):
     )
 
 
+class UserAudioTranscriptionRequest(UserRequest):
+    """
+    A class to encapsulate the details related to audio transcription request tasks.
+    Used for audio-to-text (speech-to-text) transcription via
+    /v1/audio/transcriptions.
+    """
+
+    audio_content: bytes = Field(..., description="Raw audio bytes to transcribe.")
+    audio_filename: str = Field(
+        default="audio.wav", description="Filename hint for the multipart upload."
+    )
+    language: Optional[str] = Field(
+        default=None, description="BCP-47 language code hint (e.g. 'en')."
+    )
+    response_format: str = Field(
+        default="json",
+        description="Response format: json, text, verbose_json, srt, vtt.",
+    )
+    audio_duration_s: Optional[float] = Field(
+        default=None, description="Duration of the audio clip in seconds."
+    )
+
+
 class UserResponse(BaseModel):
     """
     A class to encapsulate the most common response details from user tasks.
@@ -180,6 +203,20 @@ class UserImageGenerationResponse(UserResponse):
     images_generated: Optional[int] = Field(
         default=0,
         description="Number of images generated.",
+    )
+
+
+class UserAudioTranscriptionResponse(UserResponse):
+    """
+    A class to encapsulate the response details from audio transcription tasks.
+    """
+
+    transcribed_text: Optional[str] = Field(
+        default="", description="The transcribed text returned by the API."
+    )
+    audio_duration_s: Optional[float] = Field(
+        default=None,
+        description="Duration of the audio processed, in seconds.",
     )
 
 

--- a/genai_bench/sampling/__init__.py
+++ b/genai_bench/sampling/__init__.py
@@ -1,5 +1,6 @@
 """Import subclasses here to init registry in base class."""
 
+from genai_bench.sampling.audio import AudioSampler
 from genai_bench.sampling.base import Sampler
 from genai_bench.sampling.image import ImageSampler
 from genai_bench.sampling.text import TextSampler

--- a/genai_bench/sampling/audio.py
+++ b/genai_bench/sampling/audio.py
@@ -6,6 +6,8 @@ import struct
 import wave
 from typing import Any, List, Optional, Tuple
 
+import soundfile as sf
+
 from genai_bench.data.config import DatasetConfig
 from genai_bench.logging import init_logger
 from genai_bench.protocol import UserAudioTranscriptionRequest, UserRequest
@@ -64,8 +66,12 @@ class AudioSampler(Sampler):
         else:
             clip_duration_s = self.additional_request_params.get("clip_duration_s")
 
-        if clip_duration_s is not None and filename.endswith(".wav"):
-            audio_bytes, duration_s = _truncate_wav(audio_bytes, float(clip_duration_s))
+        if clip_duration_s is not None:
+            suffix = filename.rsplit(".", 1)[-1].lower()
+            if suffix == "wav":
+                audio_bytes, duration_s = _truncate_wav(audio_bytes, float(clip_duration_s))
+            elif suffix == "flac":
+                audio_bytes, duration_s = _truncate_flac(audio_bytes, float(clip_duration_s))
 
         return UserAudioTranscriptionRequest(
             model=self.model,
@@ -82,6 +88,30 @@ class AudioSampler(Sampler):
                 if k not in ("language", "response_format", "clip_duration_s")
             },
         )
+
+
+def _truncate_flac(audio_bytes: bytes, max_duration_s: float) -> Tuple[bytes, float]:
+    """Truncate a FLAC file to at most max_duration_s seconds.
+
+    Returns (truncated_bytes, actual_duration_s).
+    If the file is already shorter than max_duration_s, returns it unchanged.
+    Returns the original bytes unchanged on parse error.
+    """
+    try:
+        with sf.SoundFile(io.BytesIO(audio_bytes)) as f:
+            samplerate = f.samplerate
+            total_frames = f.frames
+            max_frames = int(max_duration_s * samplerate)
+            if total_frames <= max_frames:
+                return audio_bytes, total_frames / samplerate
+            samples = f.read(max_frames, dtype="int16", always_2d=True)
+
+        buf = io.BytesIO()
+        sf.write(buf, samples, samplerate, format="flac", subtype="PCM_16")
+        return buf.getvalue(), max_duration_s
+    except Exception as e:
+        logger.warning("Could not truncate FLAC, using original: %s", e)
+        return audio_bytes, 0.0
 
 
 def _truncate_wav(audio_bytes: bytes, max_duration_s: float) -> Tuple[bytes, float]:

--- a/genai_bench/sampling/audio.py
+++ b/genai_bench/sampling/audio.py
@@ -1,0 +1,104 @@
+"""Sampler for audio-to-text (speech transcription) benchmarking."""
+
+import io
+import random
+import struct
+import wave
+from typing import Any, List, Optional, Tuple
+
+from genai_bench.data.config import DatasetConfig
+from genai_bench.logging import init_logger
+from genai_bench.protocol import UserAudioTranscriptionRequest, UserRequest
+from genai_bench.sampling.base import Sampler
+from genai_bench.scenarios.base import Scenario
+
+logger = init_logger(__name__)
+
+
+class AudioSampler(Sampler):
+    """
+    Sampler for audio-to-text tasks.
+
+    Expects data to be a list of (audio_bytes, duration_s, filename) tuples
+    as returned by AudioDatasetLoader.
+
+    Supports optional clip_duration_s to truncate audio to a fixed length,
+    which is useful for benchmarking at controlled audio lengths.
+    """
+
+    input_modality = "audio"
+    supported_tasks = {"audio-to-text"}
+
+    def __init__(
+        self,
+        tokenizer,
+        model: str,
+        output_modality: str,
+        data: Any,
+        dataset_config: Optional[DatasetConfig] = None,
+        additional_request_params: Optional[dict] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            tokenizer,
+            model,
+            output_modality,
+            additional_request_params,
+            dataset_config=dataset_config,
+        )
+        self.data: List[Tuple[bytes, Optional[float], str]] = data
+
+    def sample(self, scenario: Optional[Scenario]) -> UserRequest:
+        """Sample a random audio clip and return a UserAudioTranscriptionRequest."""
+        audio_bytes, duration_s, filename = random.choice(self.data)
+
+        clip_duration_s = self.additional_request_params.get("clip_duration_s")
+        if clip_duration_s is not None and filename.endswith(".wav"):
+            audio_bytes, duration_s = _truncate_wav(audio_bytes, float(clip_duration_s))
+
+        return UserAudioTranscriptionRequest(
+            model=self.model,
+            audio_content=audio_bytes,
+            audio_filename=filename,
+            audio_duration_s=duration_s,
+            language=self.additional_request_params.get("language"),
+            response_format=self.additional_request_params.get(
+                "response_format", "json"
+            ),
+            additional_request_params={
+                k: v
+                for k, v in self.additional_request_params.items()
+                if k not in ("language", "response_format", "clip_duration_s")
+            },
+        )
+
+
+def _truncate_wav(audio_bytes: bytes, max_duration_s: float) -> Tuple[bytes, float]:
+    """Truncate a WAV file to at most max_duration_s seconds.
+
+    Returns (truncated_bytes, actual_duration_s).
+    If the file is already shorter than max_duration_s, returns it unchanged.
+    Returns the original bytes unchanged on parse error.
+    """
+    try:
+        with wave.open(io.BytesIO(audio_bytes)) as wf:
+            framerate = wf.getframerate()
+            nchannels = wf.getnchannels()
+            sampwidth = wf.getsampwidth()
+            total_frames = wf.getnframes()
+            max_frames = int(max_duration_s * framerate)
+            if total_frames <= max_frames:
+                return audio_bytes, total_frames / framerate
+            wf.rewind()
+            frames = wf.readframes(max_frames)
+
+        buf = io.BytesIO()
+        with wave.open(buf, "wb") as out:
+            out.setnchannels(nchannels)
+            out.setsampwidth(sampwidth)
+            out.setframerate(framerate)
+            out.writeframes(frames)
+        return buf.getvalue(), max_duration_s
+    except (wave.Error, struct.error, EOFError) as e:
+        logger.warning("Could not truncate WAV, using original: %s", e)
+        return audio_bytes, 0.0

--- a/genai_bench/sampling/audio.py
+++ b/genai_bench/sampling/audio.py
@@ -11,6 +11,7 @@ from genai_bench.logging import init_logger
 from genai_bench.protocol import UserAudioTranscriptionRequest, UserRequest
 from genai_bench.sampling.base import Sampler
 from genai_bench.scenarios.base import Scenario
+from genai_bench.scenarios.multimodal import AudioScenario
 
 logger = init_logger(__name__)
 
@@ -22,8 +23,13 @@ class AudioSampler(Sampler):
     Expects data to be a list of (audio_bytes, duration_s, filename) tuples
     as returned by AudioDatasetLoader.
 
-    Supports optional clip_duration_s to truncate audio to a fixed length,
-    which is useful for benchmarking at controlled audio lengths.
+    Scenario-driven mode: pass A(mean_s,std_s) as --traffic-scenario.
+    Each request samples a duration from N(mean_s, std_s) and truncates the
+    clip accordingly. This allows multiple scenarios to be benchmarked in one
+    run and plotted on the same graph (same as text-to-text N(...) scenarios).
+
+    Fixed-duration fallback: set clip_duration_s in --additional-request-params
+    to truncate all requests to a fixed length (used when --traffic-scenario dataset).
     """
 
     input_modality = "audio"
@@ -52,7 +58,12 @@ class AudioSampler(Sampler):
         """Sample a random audio clip and return a UserAudioTranscriptionRequest."""
         audio_bytes, duration_s, filename = random.choice(self.data)
 
-        clip_duration_s = self.additional_request_params.get("clip_duration_s")
+        # Scenario-driven: A(mean_s,std_s) samples duration from Gaussian distribution
+        if isinstance(scenario, AudioScenario):
+            clip_duration_s = scenario.sample()
+        else:
+            clip_duration_s = self.additional_request_params.get("clip_duration_s")
+
         if clip_duration_s is not None and filename.endswith(".wav"):
             audio_bytes, duration_s = _truncate_wav(audio_bytes, float(clip_duration_s))
 

--- a/genai_bench/scenarios/multimodal.py
+++ b/genai_bench/scenarios/multimodal.py
@@ -1,3 +1,4 @@
+import random
 from typing import Optional, Tuple
 
 from genai_bench.scenarios.base import MultiModality, Scenario, parse_params_str
@@ -66,3 +67,40 @@ class ImageModality(Scenario):
                 num_input_dimension_height=num_input_dimension_height,
                 num_input_images=optional[0],
             )
+
+
+class AudioScenario(Scenario):
+    """
+    Audio input scenario with Gaussian-distributed clip duration.
+
+    Format: A(mean_s,std_s)
+    e.g. A(10,5) — mean 10s, std 5s (matching Ming's N(10,5) convention)
+         A(30,15) — mean 30s, std 15s
+         A(60,30) — mean 60s, std 30s
+
+    sample() returns a clip duration in seconds, clamped to [1, mean+3*std].
+    """
+
+    scenario_type = MultiModality.AUDIO
+    validation_pattern = r"^A\(\d+,\d+\)$"
+
+    def __init__(self, mean_s: int, std_s: int):
+        self.mean_s = mean_s
+        self.std_s = std_s
+
+    def sample(self) -> float:
+        """Sample a clip duration in seconds from N(mean_s, std_s).
+
+        Clamped to [1s, mean+3*std].
+        """
+        duration = random.gauss(self.mean_s, self.std_s)
+        max_duration = self.mean_s + 3 * self.std_s
+        return max(1.0, min(duration, float(max_duration)))
+
+    def to_string(self) -> str:
+        return f"A({self.mean_s},{self.std_s})"
+
+    @classmethod
+    def parse(cls, params_str: str) -> "AudioScenario":
+        mean_s, std_s = parse_params_str(params_str)[0]
+        return cls(mean_s=mean_s, std_s=std_s)

--- a/genai_bench/user/openai_user.py
+++ b/genai_bench/user/openai_user.py
@@ -266,13 +266,31 @@ class OpenAIUser(BaseUser):
         if user_request.language:
             data["language"] = user_request.language
 
-        self.send_audio_request(
+        metrics_response = self.send_audio_request(
             endpoint,
             data,
             files,
             self.parse_transcription_response,
             audio_duration_s=user_request.audio_duration_s,
         )
+
+        # Fall back to tokenizer if server did not return usage.completion_tokens
+        if (
+            isinstance(metrics_response, UserAudioTranscriptionResponse)
+            and metrics_response.tokens_received is None
+            and metrics_response.transcribed_text
+        ):
+            metrics_response.tokens_received = (
+                self.environment.sampler.get_token_length(
+                    metrics_response.transcribed_text, add_special_tokens=False
+                )
+            )
+            warning_once(
+                logger,
+                "audio_tokens_received_estimated",
+                "🚨🚨🚨 No usage info in transcription response. "
+                "Estimated tokens_received from tokenizer.",
+            )
 
     def send_audio_request(
         self,
@@ -632,12 +650,17 @@ class OpenAIUser(BaseUser):
             UserAudioTranscriptionResponse: A response object with transcription.
         """
         content_type = response.headers.get("Content-Type", "")
+        tokens_received = None
         if "application/json" in content_type or "json" in content_type:
             data = response.json()
             transcribed_text = data.get("text", "")
             # verbose_json may include duration
             if audio_duration_s is None:
                 audio_duration_s = data.get("duration")
+            # Use server-reported token counts when available
+            usage = data.get("usage")
+            if usage:
+                tokens_received = usage.get("completion_tokens")
         else:
             # text / srt / vtt formats return plain text
             transcribed_text = response.text
@@ -656,6 +679,7 @@ class OpenAIUser(BaseUser):
             transcribed_text=transcribed_text,
             audio_duration_s=audio_duration_s,
             num_prefill_tokens=input_units,
+            tokens_received=tokens_received,
         )
 
     @staticmethod

--- a/genai_bench/user/openai_user.py
+++ b/genai_bench/user/openai_user.py
@@ -262,6 +262,9 @@ class OpenAIUser(BaseUser):
         data = {
             "model": user_request.model,
             "response_format": user_request.response_format,
+            "temperature": user_request.additional_request_params.get(
+                "temperature", 0.0
+            ),
         }
         if user_request.language:
             data["language"] = user_request.language

--- a/genai_bench/user/openai_user.py
+++ b/genai_bench/user/openai_user.py
@@ -641,6 +641,13 @@ class OpenAIUser(BaseUser):
         else:
             # text / srt / vtt formats return plain text
             transcribed_text = response.text
+
+        # Map audio duration to num_prefill_tokens so the metrics pipeline has
+        # a meaningful "input size" value for plots (unit: centiseconds of audio).
+        # 1 audio-second = 100 "tokens" keeps the numbers in a similar range to
+        # text benchmarks and makes axis labels interpretable.
+        input_units = int((audio_duration_s or 0.0) * 100)
+
         return UserAudioTranscriptionResponse(
             status_code=200,
             start_time=start_time,
@@ -648,7 +655,7 @@ class OpenAIUser(BaseUser):
             time_at_first_token=end_time,
             transcribed_text=transcribed_text,
             audio_duration_s=audio_duration_s,
-            num_prefill_tokens=0,
+            num_prefill_tokens=input_units,
         )
 
     @staticmethod

--- a/genai_bench/user/openai_user.py
+++ b/genai_bench/user/openai_user.py
@@ -3,6 +3,7 @@
 from locust import task
 
 import json
+import mimetypes
 import random
 import time
 from typing import Any, Callable, Dict, Optional
@@ -250,11 +251,12 @@ class OpenAIUser(BaseUser):
                 f"got {type(user_request)}"
             )
 
+        mime_type, _ = mimetypes.guess_type(user_request.audio_filename)
         files = {
             "file": (
                 user_request.audio_filename,
                 user_request.audio_content,
-                "audio/wav",
+                mime_type or "application/octet-stream",
             )
         }
         data = {

--- a/genai_bench/user/openai_user.py
+++ b/genai_bench/user/openai_user.py
@@ -13,6 +13,8 @@ from requests import Response
 from genai_bench.auth.model_auth_provider import ModelAuthProvider
 from genai_bench.logging import init_logger, warning_once
 from genai_bench.protocol import (
+    UserAudioTranscriptionRequest,
+    UserAudioTranscriptionResponse,
     UserChatRequest,
     UserChatResponse,
     UserEmbeddingRequest,
@@ -35,6 +37,7 @@ class OpenAIUser(BaseUser):
         "text-to-embeddings": "embeddings",
         "text-to-rerank": "rerank",
         "text-to-image": "images_generations",
+        "audio-to-text": "transcribe",
     }
 
     # Maps backend name to its reasoning content field in SSE delta.
@@ -233,6 +236,99 @@ class OpenAIUser(BaseUser):
         self.send_request(
             False, endpoint, payload, self.parse_images_generations_response
         )
+
+    @task
+    def transcribe(self):
+        endpoint = "/v1/audio/transcriptions"
+
+        user_request = self.sample()
+
+        if not isinstance(user_request, UserAudioTranscriptionRequest):
+            raise AttributeError(
+                f"user_request should be of type "
+                f"UserAudioTranscriptionRequest for OpenAIUser.transcribe, "
+                f"got {type(user_request)}"
+            )
+
+        files = {
+            "file": (
+                user_request.audio_filename,
+                user_request.audio_content,
+                "audio/wav",
+            )
+        }
+        data = {
+            "model": user_request.model,
+            "response_format": user_request.response_format,
+        }
+        if user_request.language:
+            data["language"] = user_request.language
+
+        self.send_audio_request(
+            endpoint,
+            data,
+            files,
+            self.parse_transcription_response,
+            audio_duration_s=user_request.audio_duration_s,
+        )
+
+    def send_audio_request(
+        self,
+        endpoint: str,
+        data: Dict[str, Any],
+        files: Dict[str, Any],
+        parse_strategy: Callable[..., UserResponse],
+        audio_duration_s: Optional[float] = None,
+    ) -> UserResponse:
+        """Send a multipart/form-data request for audio transcription."""
+        response = None
+        # Strip Content-Type so requests sets multipart boundary correctly
+        base_headers: Dict[str, str] = self.headers or {}
+        audio_headers = {
+            k: v for k, v in base_headers.items() if k.lower() != "content-type"
+        }
+        try:
+            start_time = time.monotonic()
+            response = requests.post(
+                url=f"{self.host}{endpoint}",
+                data=data,
+                files=files,
+                headers=audio_headers,
+            )
+            end_time = time.monotonic()
+
+            if response.status_code == 200:
+                metrics_response = parse_strategy(
+                    response,
+                    start_time,
+                    None,
+                    end_time,
+                    audio_duration_s=audio_duration_s,
+                )
+            else:
+                metrics_response = UserResponse(
+                    status_code=response.status_code,
+                    error_message=response.text,
+                )
+        except requests.exceptions.ConnectionError as e:
+            metrics_response = UserResponse(
+                status_code=503, error_message=f"Connection error: {e}"
+            )
+        except requests.exceptions.Timeout as e:
+            metrics_response = UserResponse(
+                status_code=408, error_message=f"Request timed out: {e}"
+            )
+        except requests.exceptions.RequestException as e:
+            metrics_response = UserResponse(
+                status_code=500,
+                error_message=str(e),
+            )
+        finally:
+            if response is not None:
+                response.close()
+
+        self.collect_metrics(metrics_response, endpoint)
+        return metrics_response
 
     def send_request(
         self,
@@ -511,6 +607,47 @@ class OpenAIUser(BaseUser):
             num_prompt_tokens if num_prompt_tokens is not None else num_prefill_tokens
         )
         return effective_prefill, num_prompt_tokens, tokens_received, reasoning_tokens
+
+    @staticmethod
+    def parse_transcription_response(
+        response: Response,
+        start_time: float,
+        _: Optional[int],
+        end_time: float,
+        audio_duration_s: Optional[float] = None,
+    ) -> UserAudioTranscriptionResponse:
+        """
+        Parses a non-streaming audio transcription response.
+
+        Args:
+            response (Response): The response object.
+            start_time (float): The time when the request was started.
+            _ (Optional[int]): Unused placeholder (num_prefill_tokens).
+            end_time (float): The time when the request was finished.
+            audio_duration_s (Optional[float]): Duration of the audio input.
+
+        Returns:
+            UserAudioTranscriptionResponse: A response object with transcription.
+        """
+        content_type = response.headers.get("Content-Type", "")
+        if "application/json" in content_type or "json" in content_type:
+            data = response.json()
+            transcribed_text = data.get("text", "")
+            # verbose_json may include duration
+            if audio_duration_s is None:
+                audio_duration_s = data.get("duration")
+        else:
+            # text / srt / vtt formats return plain text
+            transcribed_text = response.text
+        return UserAudioTranscriptionResponse(
+            status_code=200,
+            start_time=start_time,
+            end_time=end_time,
+            time_at_first_token=end_time,
+            transcribed_text=transcribed_text,
+            audio_duration_s=audio_duration_s,
+            num_prefill_tokens=0,
+        )
 
     @staticmethod
     def parse_embedding_response(

--- a/tests/data/loaders/test_audio.py
+++ b/tests/data/loaders/test_audio.py
@@ -1,0 +1,100 @@
+"""Tests for AudioDatasetLoader."""
+
+import io
+import wave
+
+import pytest
+
+from genai_bench.data.config import DatasetConfig, DatasetSourceConfig
+from genai_bench.data.loaders.audio import AudioDatasetLoader, _get_wav_duration
+
+
+def _make_wav_bytes(duration_s: float = 1.0, framerate: int = 16000) -> bytes:
+    """Create minimal in-memory WAV bytes for testing."""
+    nframes = int(duration_s * framerate)
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(framerate)
+        wf.writeframes(b"\x00\x00" * nframes)
+    return buf.getvalue()
+
+
+@pytest.fixture
+def dataset_config(tmp_path):
+    list_file = tmp_path / "files.txt"
+    list_file.write_text("")
+    return DatasetConfig(
+        source=DatasetSourceConfig(
+            type="file", path=str(list_file), file_format="txt"
+        ),
+    )
+
+
+def test_get_wav_duration_valid():
+    wav = _make_wav_bytes(duration_s=3.0, framerate=16000)
+    assert _get_wav_duration(wav) == pytest.approx(3.0, rel=1e-3)
+
+
+def test_get_wav_duration_invalid():
+    assert _get_wav_duration(b"not a wav file") == 0.0
+
+
+def test_load_wav_files(dataset_config, tmp_path):
+    wav_bytes = _make_wav_bytes(duration_s=2.0)
+    wav_path = tmp_path / "test.wav"
+    wav_path.write_bytes(wav_bytes)
+
+    loader = AudioDatasetLoader(dataset_config)
+    results = loader._process_loaded_data([str(wav_path)])
+
+    assert len(results) == 1
+    audio_bytes, duration_s, filename = results[0]
+    assert filename == "test.wav"
+    assert duration_s == pytest.approx(2.0, rel=1e-3)
+    assert len(audio_bytes) > 0
+
+
+def test_skip_missing_file(dataset_config, tmp_path):
+    wav_path = tmp_path / "real.wav"
+    wav_path.write_bytes(_make_wav_bytes())
+    missing_path = tmp_path / "missing.wav"
+
+    loader = AudioDatasetLoader(dataset_config)
+    results = loader._process_loaded_data([str(missing_path), str(wav_path)])
+
+    assert len(results) == 1
+    assert results[0][2] == "real.wav"
+
+
+def test_skip_unsupported_extension(dataset_config, tmp_path):
+    txt_path = tmp_path / "audio.txt"
+    txt_path.write_text("not audio")
+    wav_path = tmp_path / "audio.wav"
+    wav_path.write_bytes(_make_wav_bytes())
+
+    loader = AudioDatasetLoader(dataset_config)
+    results = loader._process_loaded_data([str(txt_path), str(wav_path)])
+
+    assert len(results) == 1
+    assert results[0][2] == "audio.wav"
+
+
+def test_raises_when_no_valid_files(dataset_config, tmp_path):
+    loader = AudioDatasetLoader(dataset_config)
+    with pytest.raises(ValueError, match="No valid audio files"):
+        loader._process_loaded_data(["/nonexistent/file.wav"])
+
+
+def test_non_wav_has_none_duration(dataset_config, tmp_path):
+    mp3_path = tmp_path / "audio.mp3"
+    mp3_path.write_bytes(b"fake mp3 data")
+
+    loader = AudioDatasetLoader(dataset_config)
+    results = loader._process_loaded_data([str(mp3_path)])
+
+    assert len(results) == 1
+    _, duration_s, filename = results[0]
+    assert duration_s is None
+    assert filename == "audio.mp3"

--- a/tests/metrics/test_audio_metrics.py
+++ b/tests/metrics/test_audio_metrics.py
@@ -1,0 +1,80 @@
+"""Tests for audio transcription metrics calculation."""
+
+from unittest.mock import MagicMock
+
+from genai_bench.metrics.request_metrics_collector import RequestMetricsCollector
+from genai_bench.protocol import UserAudioTranscriptionResponse
+
+
+def _make_audio_response(transcribed_text: str, duration_s: float = 10.0):
+    """Create a mock UserAudioTranscriptionResponse."""
+    mock = MagicMock(spec=UserAudioTranscriptionResponse)
+    mock.status_code = 200
+    mock.transcribed_text = transcribed_text
+    mock.audio_duration_s = duration_s
+    mock.num_prefill_tokens = int(duration_s * 100)
+    mock.time_at_first_token = 1000.5
+    mock.start_time = 1000.0
+    mock.end_time = 1000.5
+    return mock
+
+
+def test_audio_metrics_with_transcription():
+    """output metrics are populated from transcribed character count."""
+    response = _make_audio_response("Hello world", duration_s=5.0)
+    collector = RequestMetricsCollector()
+    collector.calculate_metrics(response)
+
+    assert collector.metrics.num_input_tokens == 500  # 5.0 * 100
+    assert collector.metrics.e2e_latency == 0.5
+    assert collector.metrics.num_output_tokens == len("Hello world")
+    assert collector.metrics.output_latency == collector.metrics.e2e_latency
+    assert collector.metrics.tpot > 0
+    assert collector.metrics.output_inference_speed > 0
+    assert collector.metrics.output_throughput > 0
+    assert collector.metrics.num_reasoning_tokens == 0
+
+
+def test_audio_metrics_empty_transcription():
+    """Empty transcription resets output metrics to 0."""
+    response = _make_audio_response("", duration_s=3.0)
+    collector = RequestMetricsCollector()
+    collector.calculate_metrics(response)
+
+    assert collector.metrics.num_output_tokens == 0
+    assert collector.metrics.tpot == 0
+    assert collector.metrics.output_inference_speed == 0
+    assert collector.metrics.output_throughput == 0
+
+
+def test_audio_metrics_single_char_transcription():
+    """Single character (<=1) resets output metrics to 0."""
+    response = _make_audio_response("x", duration_s=2.0)
+    collector = RequestMetricsCollector()
+    collector.calculate_metrics(response)
+
+    assert collector.metrics.num_output_tokens == 1
+    assert collector.metrics.tpot == 0
+    assert collector.metrics.output_inference_speed == 0
+    assert collector.metrics.output_throughput == 0
+
+
+def test_audio_metrics_none_transcription():
+    """None transcribed_text is treated as empty string."""
+    response = _make_audio_response("", duration_s=4.0)
+    response.transcribed_text = None
+    collector = RequestMetricsCollector()
+    collector.calculate_metrics(response)
+
+    assert collector.metrics.num_output_tokens == 0
+    assert collector.metrics.tpot == 0
+
+
+def test_audio_metrics_total_tokens():
+    """total_tokens = input tokens + output (char) tokens."""
+    text = "abcdefghij"  # 10 chars
+    response = _make_audio_response(text, duration_s=5.0)
+    collector = RequestMetricsCollector()
+    collector.calculate_metrics(response)
+
+    assert collector.metrics.total_tokens == 500 + 10

--- a/tests/metrics/test_audio_metrics.py
+++ b/tests/metrics/test_audio_metrics.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from genai_bench.metrics.request_metrics_collector import RequestMetricsCollector
 from genai_bench.protocol import UserAudioTranscriptionResponse
 
@@ -20,54 +22,56 @@ def _make_audio_response(transcribed_text: str, duration_s: float = 10.0):
 
 
 def test_audio_metrics_with_transcription():
-    """output metrics are populated from transcribed character count."""
+    """output_inference_speed stores RTF = audio_duration_s / e2e_latency."""
+    # duration=5.0s, e2e_latency = end-start = 1000.5-1000.0 = 0.5s
+    # RTF = 5.0 / 0.5 = 10.0
     response = _make_audio_response("Hello world", duration_s=5.0)
     collector = RequestMetricsCollector()
     collector.calculate_metrics(response)
 
     assert collector.metrics.num_input_tokens == 500  # 5.0 * 100
-    assert collector.metrics.e2e_latency == 0.5
+    assert collector.metrics.e2e_latency == pytest.approx(0.5)
     assert collector.metrics.num_output_tokens == len("Hello world")
     assert collector.metrics.output_latency == collector.metrics.e2e_latency
-    assert collector.metrics.tpot > 0
-    assert collector.metrics.output_inference_speed > 0
-    assert collector.metrics.output_throughput > 0
+    assert collector.metrics.output_inference_speed == pytest.approx(10.0)  # RTF
+    assert collector.metrics.tpot == 0
+    assert collector.metrics.output_throughput == 0
     assert collector.metrics.num_reasoning_tokens == 0
 
 
 def test_audio_metrics_empty_transcription():
-    """Empty transcription resets output metrics to 0."""
+    """Empty transcription: output_tokens=0, RTF still computed from duration."""
     response = _make_audio_response("", duration_s=3.0)
     collector = RequestMetricsCollector()
     collector.calculate_metrics(response)
 
     assert collector.metrics.num_output_tokens == 0
     assert collector.metrics.tpot == 0
-    assert collector.metrics.output_inference_speed == 0
     assert collector.metrics.output_throughput == 0
-
-
-def test_audio_metrics_single_char_transcription():
-    """Single character (<=1) resets output metrics to 0."""
-    response = _make_audio_response("x", duration_s=2.0)
-    collector = RequestMetricsCollector()
-    collector.calculate_metrics(response)
-
-    assert collector.metrics.num_output_tokens == 1
-    assert collector.metrics.tpot == 0
-    assert collector.metrics.output_inference_speed == 0
-    assert collector.metrics.output_throughput == 0
+    # RTF = 3.0 / 0.5 = 6.0
+    assert collector.metrics.output_inference_speed == pytest.approx(6.0)
 
 
 def test_audio_metrics_none_transcription():
-    """None transcribed_text is treated as empty string."""
+    """None transcribed_text treated as empty string; RTF still computed."""
     response = _make_audio_response("", duration_s=4.0)
     response.transcribed_text = None
     collector = RequestMetricsCollector()
     collector.calculate_metrics(response)
 
     assert collector.metrics.num_output_tokens == 0
-    assert collector.metrics.tpot == 0
+    # RTF = 4.0 / 0.5 = 8.0
+    assert collector.metrics.output_inference_speed == pytest.approx(8.0)
+
+
+def test_audio_metrics_zero_duration():
+    """Zero audio duration gives RTF=0."""
+    response = _make_audio_response("Hello", duration_s=0.0)
+    response.audio_duration_s = 0.0
+    collector = RequestMetricsCollector()
+    collector.calculate_metrics(response)
+
+    assert collector.metrics.output_inference_speed == 0.0
 
 
 def test_audio_metrics_total_tokens():

--- a/tests/metrics/test_audio_metrics.py
+++ b/tests/metrics/test_audio_metrics.py
@@ -8,7 +8,11 @@ from genai_bench.metrics.request_metrics_collector import RequestMetricsCollecto
 from genai_bench.protocol import UserAudioTranscriptionResponse
 
 
-def _make_audio_response(transcribed_text: str, duration_s: float = 10.0):
+def _make_audio_response(
+    transcribed_text: str,
+    duration_s: float = 10.0,
+    tokens_received: int = None,
+):
     """Create a mock UserAudioTranscriptionResponse."""
     mock = MagicMock(spec=UserAudioTranscriptionResponse)
     mock.status_code = 200
@@ -18,30 +22,29 @@ def _make_audio_response(transcribed_text: str, duration_s: float = 10.0):
     mock.time_at_first_token = 1000.5
     mock.start_time = 1000.0
     mock.end_time = 1000.5
+    mock.tokens_received = tokens_received
     return mock
 
 
-def test_audio_metrics_with_transcription():
-    """output_inference_speed stores RTF = audio_duration_s / e2e_latency."""
-    # duration=5.0s, e2e_latency = end-start = 1000.5-1000.0 = 0.5s
-    # RTF = 5.0 / 0.5 = 10.0
-    response = _make_audio_response("Hello world", duration_s=5.0)
+def test_audio_metrics_with_tokens():
+    """TPOT and output_throughput computed from real token count."""
+    # duration=5.0s, e2e_latency=0.5s, RTF=10.0, tokens=4
+    response = _make_audio_response("Hello world", duration_s=5.0, tokens_received=4)
     collector = RequestMetricsCollector()
     collector.calculate_metrics(response)
 
     assert collector.metrics.num_input_tokens == 500  # 5.0 * 100
     assert collector.metrics.e2e_latency == pytest.approx(0.5)
-    assert collector.metrics.num_output_tokens == len("Hello world")
-    assert collector.metrics.output_latency == collector.metrics.e2e_latency
+    assert collector.metrics.num_output_tokens == 4
     assert collector.metrics.output_inference_speed == pytest.approx(10.0)  # RTF
-    assert collector.metrics.tpot == 0
-    assert collector.metrics.output_throughput == 0
+    assert collector.metrics.tpot == pytest.approx(0.5 / 3)  # latency / (tokens-1)
+    assert collector.metrics.output_throughput == pytest.approx(3 / 0.5)
     assert collector.metrics.num_reasoning_tokens == 0
 
 
-def test_audio_metrics_empty_transcription():
-    """Empty transcription: output_tokens=0, RTF still computed from duration."""
-    response = _make_audio_response("", duration_s=3.0)
+def test_audio_metrics_zero_tokens():
+    """Zero tokens: RTF still computed, TPOT and throughput are 0."""
+    response = _make_audio_response("", duration_s=3.0, tokens_received=0)
     collector = RequestMetricsCollector()
     collector.calculate_metrics(response)
 
@@ -52,10 +55,9 @@ def test_audio_metrics_empty_transcription():
     assert collector.metrics.output_inference_speed == pytest.approx(6.0)
 
 
-def test_audio_metrics_none_transcription():
-    """None transcribed_text treated as empty string; RTF still computed."""
-    response = _make_audio_response("", duration_s=4.0)
-    response.transcribed_text = None
+def test_audio_metrics_none_tokens_falls_to_zero():
+    """None tokens_received treated as 0."""
+    response = _make_audio_response("Hello", duration_s=4.0, tokens_received=None)
     collector = RequestMetricsCollector()
     collector.calculate_metrics(response)
 
@@ -66,7 +68,7 @@ def test_audio_metrics_none_transcription():
 
 def test_audio_metrics_zero_duration():
     """Zero audio duration gives RTF=0."""
-    response = _make_audio_response("Hello", duration_s=0.0)
+    response = _make_audio_response("Hello", duration_s=0.0, tokens_received=2)
     response.audio_duration_s = 0.0
     collector = RequestMetricsCollector()
     collector.calculate_metrics(response)
@@ -75,10 +77,9 @@ def test_audio_metrics_zero_duration():
 
 
 def test_audio_metrics_total_tokens():
-    """total_tokens = input tokens + output (char) tokens."""
-    text = "abcdefghij"  # 10 chars
-    response = _make_audio_response(text, duration_s=5.0)
+    """total_tokens = input tokens + output tokens."""
+    response = _make_audio_response("Hello world", duration_s=5.0, tokens_received=3)
     collector = RequestMetricsCollector()
     collector.calculate_metrics(response)
 
-    assert collector.metrics.total_tokens == 500 + 10
+    assert collector.metrics.total_tokens == 500 + 3

--- a/tests/sampling/test_audio.py
+++ b/tests/sampling/test_audio.py
@@ -1,0 +1,105 @@
+"""Tests for AudioSampler and _truncate_wav."""
+
+import io
+import wave
+from unittest.mock import MagicMock
+
+import pytest
+
+from genai_bench.protocol import UserAudioTranscriptionRequest
+from genai_bench.sampling.audio import AudioSampler, _truncate_wav
+from genai_bench.scenarios.multimodal import AudioScenario
+
+
+def _make_wav_bytes(duration_s: float = 3.0, framerate: int = 16000) -> bytes:
+    nframes = int(duration_s * framerate)
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(framerate)
+        wf.writeframes(b"\x00\x00" * nframes)
+    return buf.getvalue()
+
+
+@pytest.fixture
+def sampler():
+    wav = _make_wav_bytes(duration_s=5.0)
+    data = [(wav, 5.0, "test.wav")]
+    tokenizer = MagicMock()
+    return AudioSampler(
+        tokenizer=tokenizer,
+        model="whisper",
+        output_modality="text",
+        data=data,
+        additional_request_params={"response_format": "json"},
+    )
+
+
+def test_sample_returns_request(sampler):
+    request = sampler.sample(scenario=None)
+    assert isinstance(request, UserAudioTranscriptionRequest)
+    assert request.model == "whisper"
+    assert request.audio_filename == "test.wav"
+    assert request.response_format == "json"
+
+
+def test_sample_with_audio_scenario(sampler):
+    scenario = AudioScenario(mean_s=3, std_s=1)
+    request = sampler.sample(scenario=scenario)
+    assert isinstance(request, UserAudioTranscriptionRequest)
+    # Duration should be truncated to scenario sample, wav gets re-encoded
+    assert request.audio_duration_s is not None
+    assert request.audio_duration_s <= 3 + 3 * 1  # within 3 std
+
+
+def test_sample_with_clip_duration_param():
+    wav = _make_wav_bytes(duration_s=10.0)
+    data = [(wav, 10.0, "long.wav")]
+    tokenizer = MagicMock()
+    s = AudioSampler(
+        tokenizer=tokenizer,
+        model="whisper",
+        output_modality="text",
+        data=data,
+        additional_request_params={"clip_duration_s": 2.0, "response_format": "json"},
+    )
+    request = s.sample(scenario=None)
+    assert request.audio_duration_s == pytest.approx(2.0, rel=1e-3)
+
+
+def test_sample_non_wav_skips_truncation():
+    mp3_data = b"fake mp3 content"
+    data = [(mp3_data, None, "audio.mp3")]
+    tokenizer = MagicMock()
+    s = AudioSampler(
+        tokenizer=tokenizer,
+        model="whisper",
+        output_modality="text",
+        data=data,
+        additional_request_params={"clip_duration_s": 2.0, "response_format": "json"},
+    )
+    request = s.sample(scenario=None)
+    # mp3 is not truncated, original bytes preserved
+    assert request.audio_content == mp3_data
+
+
+def test_truncate_wav_shorter_than_max():
+    wav = _make_wav_bytes(duration_s=2.0)
+    result_bytes, result_dur = _truncate_wav(wav, max_duration_s=5.0)
+    # File shorter than max — returned unchanged
+    assert result_dur == pytest.approx(2.0, rel=1e-3)
+    assert result_bytes == wav
+
+
+def test_truncate_wav_longer_than_max():
+    wav = _make_wav_bytes(duration_s=5.0)
+    result_bytes, result_dur = _truncate_wav(wav, max_duration_s=2.0)
+    assert result_dur == pytest.approx(2.0, rel=1e-3)
+    assert len(result_bytes) < len(wav)
+
+
+def test_truncate_wav_invalid_bytes():
+    result_bytes, result_dur = _truncate_wav(b"not a wav", max_duration_s=3.0)
+    assert result_bytes == b"not a wav"
+    assert result_dur == 0.0


### PR DESCRIPTION
## Summary
- Add \`audio-to-text\` task to benchmark ASR/STT models (e.g. Whisper) via OpenAI-compatible \`/v1/audio/transcriptions\`
- New \`AudioDatasetLoader\` reads a text file listing audio file paths (WAV/MP3/FLAC/M4A)
- New \`AudioSampler\` samples random clips with optional \`clip_duration_s\` truncation for controlled-length benchmarks
- \`OpenAIUser.transcribe()\` sends multipart/form-data POST requests and parses JSON/text/verbose_json responses
- Supports \`language\`, \`response_format\`, and \`clip_duration_s\` via \`--additional-request-params\`

## Usage
\`\`\`bash
# Prepare a text file listing one audio path per line
echo \"/path/to/speech.wav\" > audio_files.txt

genai-bench benchmark \\
  --api-backend vllm \\
  --api-base http://localhost:8080 \\
  --task audio-to-text \\
  --model vllm-model \\
  --dataset-path audio_files.txt \\
  --num-concurrency 1 4 8 \\
  --traffic-scenario \"dataset\" \\
  --additional-request-params '{\"response_format\": \"json\", \"language\": \"en\", \"clip_duration_s\": 30}'
\`\`\`

## Test plan
- [ ] \`make lint\` passes (mypy + ruff)
- [ ] Existing \`tests/user/test_openai_user.py\` (45 tests) all pass
- [ ] Manual E2E test against a running Whisper vLLM endpoint