### PR TITLE
feat: add RTX-PRO-6000 to server-gpu-type choices

### DIFF
--- a/genai_bench/cli/option_groups.py
+++ b/genai_bench/cli/option_groups.py
@@ -369,7 +369,16 @@ def server_options(func):
     func = click.option(
         "--server-gpu-type",
         type=click.Choice(
-            ["H100", "A100-80G", "A100-40G", "MI300", "A10", "H200", "B200"],
+            [
+                "H100",
+                "A100-80G",
+                "A100-40G",
+                "MI300",
+                "A10",
+                "H200",
+                "B200",
+                "RTX-PRO-6000",
+            ],
             case_sensitive=True,
         ),
         required=False,


### PR DESCRIPTION
## Description
Add `RTX-PRO-6000` as a valid option for the `--server-gpu-type` CLI flag, so benchmark results can be tagged when running against NVIDIA RTX PRO 6000 Blackwell servers.

## Related Issue
N/A


## Changes
- Add `"RTX-PRO-6000"` to the `--server-gpu-type` `click.Choice` list in `genai_bench/cli/option_groups.py`.

## Correctness Tests
- Ran `make check` — lint and format pass.
- Verified locally that `genai-bench benchmark --server-gpu-type RTX-PRO-6000 ...` is accepted (and that other values still validate as before).

---
<details>
<summary> Checklist </summary>

- [x] I have rebased my branch on top of the latest main branch (`git pull origin main`)
- [x] I have run `make check` to ensure code is properly formatted and passes all lint checks
- [ ] I have run `make test` or `make test_changed` to verify test coverage (~90% required)
- [ ] I have added tests that fail without my code changes (for bug fixes)
- [ ] I have added tests covering variants of new features (for new features)

</details>