### PR TITLE
fix(metrics): don't crash on short-output runs with no measurable tpot

### DIFF
--- a/genai_bench/metrics/aggregated_metrics_collector.py
+++ b/genai_bench/metrics/aggregated_metrics_collector.py
@@ -37,8 +37,7 @@ class AggregatedMetricsCollector:
 
     def add_single_request_metrics(self, metrics: RequestLevelMetrics):
         """Adds metrics from a single request to the aggregated metrics."""
-        if self._should_filter_metrics(metrics):
-            return
+        self._null_unreliable_output_metrics(metrics)
 
         # Store individual request metrics
         self.all_request_metrics.append(metrics)
@@ -68,17 +67,41 @@ class AggregatedMetricsCollector:
             # Update live metrics aggregation
             self._update_live_metrics()
 
-    @staticmethod
-    def _should_filter_metrics(metrics: RequestLevelMetrics) -> bool:
-        """Filters metrics based on out of range TPOT/inference speed."""
-        inference_speed = metrics.output_inference_speed
-        if inference_speed is not None and inference_speed > 1000:
+    # Above this, the per-token output metrics are treated as unmeasurable
+    # rather than real. A short response that streams back in one (or very few)
+    # chunks collapses output_latency toward zero, so the derived per-token
+    # rates explode; genuine decode speeds for current models stay well under
+    # this bound.
+    MAX_PLAUSIBLE_OUTPUT_INFERENCE_SPEED = 1000  # tokens/s
+
+    @classmethod
+    def _null_unreliable_output_metrics(cls, metrics: RequestLevelMetrics) -> None:
+        """Null per-token output metrics that could not be measured reliably.
+
+        When a response is too short to observe inter-token timing (e.g. it
+        arrives in a single streaming chunk), ``output_latency`` collapses
+        toward zero and the derived per-token metrics — ``tpot``,
+        ``output_inference_speed`` and ``output_throughput`` — blow up to
+        implausible values. Such a request used to be dropped wholesale, which
+        (a) discarded its still-valid ttft / e2e / token-count data and (b)
+        could leave the run with zero usable ``tpot`` samples, crashing
+        aggregation. Instead we null only the unreliable derived fields and keep
+        the request; aggregation then simply has fewer (or zero) samples for
+        those metrics, which it now tolerates.
+        """
+        speed = metrics.output_inference_speed
+        if speed is not None and speed > cls.MAX_PLAUSIBLE_OUTPUT_INFERENCE_SPEED:
             logger.warning(
-                f"Metric has abnormal inference speed: {inference_speed} tokens/s."
-                " Filtering it out."
+                f"Output inference speed {speed:.1f} tokens/s exceeds the "
+                f"plausible maximum ({cls.MAX_PLAUSIBLE_OUTPUT_INFERENCE_SPEED} "
+                f"tokens/s); the response was likely too short to measure "
+                f"per-token timing. Nulling tpot, output_inference_speed and "
+                f"output_throughput for this request (ttft, e2e latency and "
+                f"token counts are kept)."
             )
-            return True
-        return False
+            metrics.tpot = None
+            metrics.output_inference_speed = None
+            metrics.output_throughput = None
 
     def _update_live_metrics(self):
         """Calculates live metrics like avg, max, min, and percentiles."""
@@ -171,11 +194,19 @@ class AggregatedMetricsCollector:
                 if warmup_number <= i < len(self.all_request_metrics) - cooldown_number:
                     values.append(value)
 
-            # Validate that all values are valid for processing
+            # A metric can legitimately have zero samples — e.g. tpot,
+            # output_inference_speed or output_throughput on a short-output run
+            # where every response was too brief to measure per-token timing
+            # (see _null_unreliable_output_metrics). Leave its aggregate stats
+            # unset (None) and carry on rather than aborting the whole run and
+            # discarding every other metric.
             if not values:
-                raise ValueError(
-                    f"No values found for metric '{key}'. This should never happen!"
+                logger.warning(
+                    f"No values found for metric '{key}' across "
+                    f"{len(self.all_request_metrics)} request(s); leaving its "
+                    f"aggregate stats unset."
                 )
+                continue
 
             percentiles = np.percentile(values, [25, 50, 75, 90, 95, 99])
             stat_field = getattr(self.aggregated_metrics.stats, key)

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -158,7 +158,10 @@ def test_event_aggregation(aggregated_metrics_collector, locust_environment):
     assert output_throughput == 14.0
 
 
-def test_filter_metrics(aggregated_metrics_collector):
+def test_null_unreliable_output_metrics_keeps_request(aggregated_metrics_collector):
+    # A response too short to measure per-token timing yields an implausibly
+    # high inference speed. The request must be KEPT (its ttft / e2e / token
+    # counts are still valid), with only the unreliable per-token metrics nulled.
     metrics1 = RequestLevelMetrics(
         ttft=0.1,
         tpot=0.0000002,
@@ -168,12 +171,22 @@ def test_filter_metrics(aggregated_metrics_collector):
         output_throughput=11.111,
         num_input_tokens=2,
         num_output_tokens=10,
-        output_inference_speed=1 / 0.0000002,
+        output_inference_speed=1 / 0.0000002,  # 5,000,000 tokens/s
         total_tokens=12,
     )
 
     aggregated_metrics_collector.add_single_request_metrics(metrics1)
-    assert metrics1 not in aggregated_metrics_collector.all_request_metrics
+
+    assert metrics1 in aggregated_metrics_collector.all_request_metrics
+    # Unreliable per-token metrics are nulled...
+    assert metrics1.tpot is None
+    assert metrics1.output_inference_speed is None
+    assert metrics1.output_throughput is None
+    # ...while the directly-measured fields are preserved.
+    assert metrics1.ttft == 0.1
+    assert metrics1.e2e_latency == 1.0
+    assert metrics1.num_output_tokens == 10
+    assert metrics1.input_throughput == 20.0
 
     embedding_metrics = RequestLevelMetrics(
         ttft=0.1,
@@ -184,6 +197,48 @@ def test_filter_metrics(aggregated_metrics_collector):
 
     aggregated_metrics_collector.add_single_request_metrics(embedding_metrics)
     assert embedding_metrics in aggregated_metrics_collector.all_request_metrics
+
+
+def test_aggregate_short_output_run_does_not_crash(
+    aggregated_metrics_collector, caplog
+):
+    """Regression: a short-output run where every response is too brief to
+    measure per-token timing must not crash aggregation.
+
+    Previously the fast requests were dropped for "abnormal inference speed",
+    leaving only degenerate samples, so the tpot value list was empty and
+    aggregate_metrics_data raised "No values found for metric 'tpot'. This
+    should never happen!", aborting the whole benchmark.
+    """
+    # Five fast, short responses: 10 output tokens in ~5 ms => ~1800 tokens/s,
+    # above MAX_PLAUSIBLE_OUTPUT_INFERENCE_SPEED.
+    for _ in range(5):
+        m = RequestLevelMetrics(
+            ttft=0.10,
+            tpot=0.005 / 9,
+            e2e_latency=0.105,
+            output_latency=0.005,
+            input_throughput=24620.0,
+            output_throughput=9 / 0.005,
+            num_input_tokens=2462,
+            num_output_tokens=10,
+            output_inference_speed=9 / 0.005,  # 1800 tokens/s
+            total_tokens=2472,
+        )
+        aggregated_metrics_collector.add_single_request_metrics(m)
+
+    with caplog.at_level(logging.WARNING):
+        aggregated_metrics_collector.aggregate_metrics_data(0.0, 10.0, 4.0, None, None)
+
+    agg = aggregated_metrics_collector.aggregated_metrics
+    # No crash; the run is still counted and the reliable metrics aggregate.
+    assert agg.num_requests == 5
+    assert agg.stats.ttft.mean == pytest.approx(0.10)
+    assert agg.stats.num_output_tokens.mean == pytest.approx(10)
+    # The unmeasurable per-token metrics are left unset rather than fabricated.
+    assert agg.stats.tpot.mean is None
+    assert agg.stats.output_inference_speed.mean is None
+    assert "No values found for metric 'tpot'" in caplog.text
 
 
 def test_update_live_metrics(aggregated_metrics_collector):


### PR DESCRIPTION
### Why?

Benchmarking a short-output workload (e.g. guided-JSON classification emitting ~20 tokens) crashes the whole run with `No values found for metric 'tpot'. This should never happen!`. Two bugs compound: short responses that stream back in one chunk collapse `output_latency` toward zero, so the derived per-token rates exceed the plausibility bound; `_should_filter_metrics` then drops those requests entirely (discarding their valid ttft/e2e/token data), and `aggregate_metrics_data` raises a hard error once the `tpot` sample list ends up empty — aborting every metric and every concurrency level.

### How?

Keep the request and null only the unreliable per-token fields (`tpot`, `output_inference_speed`, `output_throughput`) instead of dropping it, and let aggregation leave a metric's stats unset (with a warning) when it has zero samples instead of raising. A regression test reproduces the short-output crash.

<sub>Generated with Claude Code</sub>