### PR TITLE
Fix/ssl verify under gevent

### DIFF
--- a/genai_bench/user/azure_openai_user.py
+++ b/genai_bench/user/azure_openai_user.py
@@ -19,6 +19,7 @@ from genai_bench.protocol import (
     UserResponse,
 )
 from genai_bench.user.base_user import BaseUser
+from genai_bench.utils import get_requests_verify
 
 logger = init_logger(__name__)
 
@@ -167,6 +168,7 @@ class AzureOpenAIUser(BaseUser):
                 json=payload,
                 stream=stream,
                 headers=self.headers,
+                verify=get_requests_verify(),
             )
             non_stream_post_end_time = time.monotonic()
 

--- a/genai_bench/user/cohere_user.py
+++ b/genai_bench/user/cohere_user.py
@@ -17,6 +17,7 @@ from genai_bench.protocol import (
     UserResponse,
 )
 from genai_bench.user.base_user import BaseUser
+from genai_bench.utils import get_requests_verify
 
 logger = init_logger(__name__)
 
@@ -148,6 +149,7 @@ class CohereUser(BaseUser):
                 headers=self.headers,
                 json=payload,
                 stream=stream,
+                verify=get_requests_verify(),
             )
             response.raise_for_status()
             logger.debug(

--- a/genai_bench/user/gcp_vertex_user.py
+++ b/genai_bench/user/gcp_vertex_user.py
@@ -19,6 +19,7 @@ from genai_bench.protocol import (
     UserResponse,
 )
 from genai_bench.user.base_user import BaseUser
+from genai_bench.utils import get_requests_verify
 
 logger = init_logger(__name__)
 
@@ -216,6 +217,7 @@ class GCPVertexUser(BaseUser):
                 json=payload,
                 stream=stream,
                 headers=self.headers,
+                verify=get_requests_verify(),
             )
             non_stream_post_end_time = time.monotonic()
 

--- a/genai_bench/user/openai_user.py
+++ b/genai_bench/user/openai_user.py
@@ -25,6 +25,7 @@ from genai_bench.protocol import (
     UserTextToSpeechResponse,
 )
 from genai_bench.user.base_user import BaseUser
+from genai_bench.utils import get_requests_verify
 
 logger = init_logger(__name__)
 
@@ -341,6 +342,7 @@ class OpenAIUser(BaseUser):
                 json=payload,
                 stream=stream,
                 headers=self.headers,
+                verify=get_requests_verify(),
             )
             non_stream_post_end_time = time.monotonic()
 

--- a/genai_bench/user/together_user.py
+++ b/genai_bench/user/together_user.py
@@ -20,6 +20,7 @@ from genai_bench.protocol import (
     UserResponse,
 )
 from genai_bench.user.base_user import BaseUser
+from genai_bench.utils import get_requests_verify
 
 logger = init_logger(__name__)
 
@@ -169,6 +170,7 @@ class TogetherUser(BaseUser):
                 json=payload,
                 stream=stream,
                 headers=self.headers,
+                verify=get_requests_verify(),
             )
             non_stream_post_end_time = time.monotonic()
 

--- a/genai_bench/utils.py
+++ b/genai_bench/utils.py
@@ -1,9 +1,33 @@
 import os
 import re
+from typing import Union
 
 from genai_bench.logging import init_logger
 
 logger = init_logger(__name__)
+
+_SSL_VERIFY_ENV_VARS = (
+    "GENAI_BENCH_SSL_CA_BUNDLE",
+    "REQUESTS_CA_BUNDLE",
+    "SSL_CERT_FILE",
+)
+
+
+def get_requests_verify() -> Union[bool, str]:
+    """Return the SSL verify setting for requests under gevent.
+
+    Gevent monkey-patches ssl before requests runs, so relying on implicit
+    CA discovery is unreliable for private CAs. Pass this value as ``verify=``
+    on every ``requests`` call.
+
+    Reads, in order: GENAI_BENCH_SSL_CA_BUNDLE, REQUESTS_CA_BUNDLE,
+    SSL_CERT_FILE. Falls back to True (default certifi bundle) when unset.
+    """
+    for env_var in _SSL_VERIFY_ENV_VARS:
+        ca_bundle = os.environ.get(env_var)
+        if ca_bundle:
+            return ca_bundle
+    return True
 
 
 def sanitize_string(input_str: str):

--- a/tests/test_ssl_utils.py
+++ b/tests/test_ssl_utils.py
@@ -1,5 +1,3 @@
-import os
-
 from genai_bench.utils import get_requests_verify
 
 

--- a/tests/test_ssl_utils.py
+++ b/tests/test_ssl_utils.py
@@ -1,0 +1,30 @@
+import os
+
+from genai_bench.utils import get_requests_verify
+
+
+def test_get_requests_verify_defaults_to_true(monkeypatch):
+    for env_var in (
+        "GENAI_BENCH_SSL_CA_BUNDLE",
+        "REQUESTS_CA_BUNDLE",
+        "SSL_CERT_FILE",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+
+    assert get_requests_verify() is True
+
+
+def test_get_requests_verify_prefers_genai_bench_env(monkeypatch):
+    monkeypatch.setenv("GENAI_BENCH_SSL_CA_BUNDLE", "/tmp/genai-ca.pem")
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", "/tmp/requests-ca.pem")
+    monkeypatch.setenv("SSL_CERT_FILE", "/tmp/ssl-cert.pem")
+
+    assert get_requests_verify() == "/tmp/genai-ca.pem"
+
+
+def test_get_requests_verify_falls_back_to_requests_ca_bundle(monkeypatch):
+    monkeypatch.delenv("GENAI_BENCH_SSL_CA_BUNDLE", raising=False)
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", "/tmp/requests-ca.pem")
+    monkeypatch.setenv("SSL_CERT_FILE", "/tmp/ssl-cert.pem")
+
+    assert get_requests_verify() == "/tmp/requests-ca.pem"

--- a/tests/user/test_gcp_vertex_user.py
+++ b/tests/user/test_gcp_vertex_user.py
@@ -16,6 +16,7 @@ from genai_bench.protocol import (
     UserResponse,
 )
 from genai_bench.user.gcp_vertex_user import GCPVertexUser
+from genai_bench.utils import get_requests_verify
 
 
 class TestGCPVertexUser:
@@ -455,6 +456,7 @@ class TestGCPVertexUser:
                 headers=vertex_user.headers,
                 json={"test": "data"},
                 stream=False,
+                verify=get_requests_verify(),
             )
 
     def test_send_request_error(self, vertex_user):

--- a/tests/user/test_openai_user.py
+++ b/tests/user/test_openai_user.py
@@ -17,6 +17,7 @@ from genai_bench.protocol import (
     UserTextToSpeechResponse,
 )
 from genai_bench.user.openai_user import OpenAIUser
+from genai_bench.utils import get_requests_verify
 
 
 def reasoning_delta_cases():
@@ -121,6 +122,7 @@ def test_chat(mock_post, mock_openai_user):
             "Authorization": "Bearer fake_api_key",
             "Content-Type": "application/json",
         },
+        verify=get_requests_verify(),
     )
 
 
@@ -183,6 +185,7 @@ def test_vision(mock_post, mock_openai_user):
             "Authorization": "Bearer fake_api_key",
             "Content-Type": "application/json",
         },
+        verify=get_requests_verify(),
     )
 
 
@@ -212,6 +215,7 @@ def test_embeddings(mock_post, mock_openai_user):
             "Authorization": "Bearer fake_api_key",
             "Content-Type": "application/json",
         },
+        verify=get_requests_verify(),
     )
 
 
@@ -1435,6 +1439,7 @@ def test_images_generations_rest_api(mock_post, mock_openai_user):
             "Authorization": "Bearer fake_api_key",
             "Content-Type": "application/json",
         },
+        verify=get_requests_verify(),
     )
 
 
@@ -1585,6 +1590,7 @@ def test_speech(mock_post, mock_openai_user):
             "Authorization": "Bearer fake_api_key",
             "Content-Type": "application/json",
         },
+        verify=get_requests_verify(),
     )
 
 
@@ -1741,6 +1747,7 @@ def test_rerank(mock_post, mock_openai_user):
             "Authorization": "Bearer fake_api_key",
             "Content-Type": "application/json",
         },
+        verify=get_requests_verify(),
     )
 
 

--- a/tests/user/test_together_user.py
+++ b/tests/user/test_together_user.py
@@ -13,6 +13,7 @@ from genai_bench.protocol import (
     UserResponse,
 )
 from genai_bench.user.together_user import TogetherUser
+from genai_bench.utils import get_requests_verify
 
 
 @pytest.fixture
@@ -144,6 +145,7 @@ def test_chat(mock_post, mock_together_user):
             "Authorization": "Bearer fake_api_key",
             "Content-Type": "application/json",
         },
+        verify=get_requests_verify(),
     )
 
 
@@ -207,6 +209,7 @@ def test_vision(mock_post, mock_together_user):
             "Authorization": "Bearer fake_api_key",
             "Content-Type": "application/json",
         },
+        verify=get_requests_verify(),
     )
 
 
@@ -236,6 +239,7 @@ def test_embeddings(mock_post, mock_together_user):
             "Authorization": "Bearer fake_api_key",
             "Content-Type": "application/json",
         },
+        verify=get_requests_verify(),
     )
 
 


### PR DESCRIPTION
## Description
Fixes intermittent SSL failures when benchmarking HTTPS APIs signed by private/corporate CAs.
genai-bench uses gevent (`monkey.patch_all()`) and `requests.post()` without an explicit `verify=` argument. Under gevent, CA bundles set via `REQUESTS_CA_BUNDLE` are not reliably applied, causing `SSLCertVerificationError` / `SSLEOFError` (surfaced as 503 connection errors).
## Related Issue
Fixes #<issue-number> (if you filed one)
## Changes
- Add `get_requests_verify()` in `genai_bench/utils.py` (reads `GENAI_BENCH_SSL_CA_BUNDLE`, `REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`)
- Pass `verify=get_requests_verify()` on all `requests.post()` calls in user backends
- Add unit tests in `tests/test_ssl_utils.py`
## Correctness Tests
```bash
pytest tests/test_ssl_utils.py -q