### PR TITLE
feat: add B300 to server-gpu-type choices

### DIFF
--- a/genai_bench/analysis/flexible_plot_report.py
+++ b/genai_bench/analysis/flexible_plot_report.py
@@ -473,7 +473,7 @@ class FlexiblePlotGenerator:
     ) -> None:
         """Plot multiple lines on the same subplot."""
         # Get colors from tab10 colormap
-        cmap = plt.cm.get_cmap("tab10")
+        cmap = plt.get_cmap("tab10")
         colors = [cmap(i) for i in range(10)]  # Get first 10 colors
         linestyles = ["-", "--", "-.", ":"]
 

--- a/genai_bench/cli/option_groups.py
+++ b/genai_bench/cli/option_groups.py
@@ -377,6 +377,7 @@ def server_options(func):
                 "A10",
                 "H200",
                 "B200",
+                "B300",
                 "RTX-PRO-6000",
             ],
             case_sensitive=True,


### PR DESCRIPTION
## Description
Adds `B300` as a selectable value for the `--server-gpu-type` option, so benchmarks can record NVIDIA B300 (Blackwell Ultra) GPU nodes.

## Related Issue
N/A

## Changes
- Added `B300` to the `--server-gpu-type` `click.Choice` list in `genai_bench/cli/option_groups.py`.

## Correctness Tests
- `genai-bench benchmark --server-gpu-type B300 ...` is now accepted; an invalid value still fails with the choice error listing `B300`.

---
<details>
<summary> Checklist </summary>

- [x] I have rebased my branch on top of the latest main branch (`git pull origin main`)
- [ ] I have run `make check` to ensure code is properly formatted and passes all lint checks
- [ ] I have run `make test` or `make test_changed` to verify test coverage (~90% required)
- [ ] I have added tests that fail without my code changes (for bug fixes)
- [ ] I have added tests covering variants of new features (for new features)

</details>
