### PR TITLE
[release] Update version to 0.0.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "genai-bench"
-version = "0.0.4"
+version = "0.0.5"
 description = "A powerful benchmark tool designed for comprehensive token-level performance evaluation of large language model (LLM) serving systems."
 authors = [{ name = "Chang Su", email = "chang.s.su@oracle.com" }]
 requires-python = ">=3.10,<3.13"


### PR DESCRIPTION
Bumps the package version from `0.0.4` to `0.0.5` in `pyproject.toml` in preparation for the v0.0.5 release.

Once merged, publish a GitHub Release with tag `v0.0.5` targeting the merge commit to trigger the `Release` workflow (tests + coverage gate, tag/pyproject version match check, PyPI publish, and multi-arch Docker image push to GHCR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)