### PR TITLE
fix(analysis): use plt.get_cmap instead of removed plt.cm.get_cmap

### DIFF
--- a/genai_bench/analysis/flexible_plot_report.py
+++ b/genai_bench/analysis/flexible_plot_report.py
@@ -473,7 +473,7 @@ class FlexiblePlotGenerator:
     ) -> None:
         """Plot multiple lines on the same subplot."""
         # Get colors from tab10 colormap
-        cmap = plt.cm.get_cmap("tab10")
+        cmap = plt.get_cmap("tab10")
         colors = [cmap(i) for i in range(10)]  # Get first 10 colors
         linestyles = ["-", "--", "-.", ":"]
 


### PR DESCRIPTION
## Problem

The `lint` job (mypy) fails on `main`:

```
genai_bench/analysis/flexible_plot_report.py:476: error: Module has no attribute "get_cmap"  [attr-defined]
```

`matplotlib.cm.get_cmap` (which `plt.cm.get_cmap` resolves to) was deprecated in matplotlib 3.7 and removed from the type stubs. Under the `matplotlib>=3.9.2` pin, mypy no longer sees the attribute. It also emits a `MatplotlibDeprecationWarning` at runtime and will break entirely once matplotlib 3.11 drops the function.

## Fix

Switch to `plt.get_cmap("tab10")` — the pyplot-level replacement recommended by matplotlib's own deprecation message. Behavior-identical, and in the type stubs so mypy passes. (`plot_report.py` already uses this form.)

Verified locally: `uv run mypy genai_bench --config-file=mypy.ini` → `Success: no issues found in 98 source files`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)