### PR TITLE
feat: add deterministic prefix pools

### DIFF
--- a/docs/user-guide/scenario-definition.md
+++ b/docs/user-guide/scenario-definition.md
@@ -140,6 +140,11 @@ Choose one of two mutually exclusive options:
    - Prefix length computed per-request as `int(num_input_tokens * ratio)`
    - Requires deterministic scenarios like `D(input_tokens,output_tokens)`
 
+To benchmark a bounded KV-cache working set instead of one shared prefix, use
+`--prefix-pool-size` together with `--prefix-len`. The sampler deterministically
+rotates through that many distinct shared prefixes. Use `--prefix-seed` to make
+the generated pool reproducible across runs and targets.
+
 #### Request format
 
 Each request follows this format:
@@ -174,6 +179,9 @@ Prefix caching has the following requirements:
    - For multiple scenarios, `prefix_len` must be `<= min(input_tokens)` across all scenarios
    - The separator will be truncated automatically if needed to maintain exact token counts
 4. **Multi-worker consistency**: The prefix is generated using a fixed random seed `(42, prefix_len)` so all workers produce the same prefix text. Different prefix lengths produce different prefix text to avoid cross-scenario cache overlap. Note: When using `--prefix-len` with multiple scenarios sharing the same prefix length, the server-side KV cache may already be warm for subsequent scenarios. Use `--warmup-ratio` to mitigate this. Note: This approach may be refined in future versions.
+5. **Prefix pools**: `--prefix-pool-size` values greater than one require
+   `--prefix-len` and local execution with `--num-workers 0`. This preserves one
+   deterministic global rotation order.
 
 #### Examples
 
@@ -227,6 +235,27 @@ genai-bench benchmark \
 ```
 
 This tests scenarios with different cache ratios (80%, 40%, 20%) while keeping the same 800-token prefix.
+
+**Using a deterministic prefix pool**:
+
+```bash
+genai-bench benchmark \
+  --task text-to-text \
+  --traffic-scenario "D(3200,16)" \
+  --prefix-len 3072 \
+  --prefix-pool-size 20 \
+  --prefix-seed 20260715 \
+  --num-workers 0 \
+  --num-concurrency 8 \
+  --api-backend sglang \
+  --api-base http://localhost:8000 \
+  --api-model-name my-model \
+  --model-tokenizer my-model
+```
+
+This rotates through 20 distinct 3,072-token prefixes, creating an aggregate
+shared-prefix working set of 61,440 tokens. Concurrency controls how many
+requests are in flight; it does not change the deterministic prefix order.
 
 **Using --prefix-ratio with multiple scenarios** (same ratio, different absolute lengths):
 

--- a/genai_bench/cli/cli.py
+++ b/genai_bench/cli/cli.py
@@ -124,6 +124,8 @@ def benchmark(
     dataset_image_column,
     prefix_len,
     prefix_ratio,
+    prefix_pool_size,
+    prefix_seed,
     num_workers,
     master_port,
     spawn_rate,
@@ -293,6 +295,8 @@ def benchmark(
         dataset_path=dataset_path,
         dataset_config=dataset_config,
         traffic_scenario=traffic_scenario,
+        prefix_pool_size=prefix_pool_size,
+        num_workers=num_workers,
     )
 
     # Handle dataset configuration
@@ -320,6 +324,8 @@ def benchmark(
         dataset_config=dataset_config_obj,
         prefix_len=prefix_len,
         prefix_ratio=prefix_ratio,
+        prefix_pool_size=prefix_pool_size,
+        prefix_seed=prefix_seed,
     )
 
     # If user did not provide scenarios but provided a dataset, default to dataset mode

--- a/genai_bench/cli/option_groups.py
+++ b/genai_bench/cli/option_groups.py
@@ -349,6 +349,22 @@ def sampling_options(func):
             "Mutually exclusive with --prefix-len."
         ),
     )(func)
+    func = click.option(
+        "--prefix-pool-size",
+        type=click.IntRange(min=1),
+        default=1,
+        help=(
+            "Number of deterministic shared prefixes to rotate through. "
+            "Values greater than 1 require --prefix-len and local execution "
+            "(--num-workers 0)."
+        ),
+    )(func)
+    func = click.option(
+        "--prefix-seed",
+        type=int,
+        default=42,
+        help="Stable seed used to generate shared prefixes.",
+    )(func)
     return func
 
 

--- a/genai_bench/cli/validation.py
+++ b/genai_bench/cli/validation.py
@@ -457,7 +457,14 @@ def _get_min_input_tokens(scenario: Scenario) -> int | None:
 
 
 def validate_prefix_options(
-    prefix_len, prefix_ratio, task, dataset_path, dataset_config, traffic_scenario
+    prefix_len,
+    prefix_ratio,
+    task,
+    dataset_path,
+    dataset_config,
+    traffic_scenario,
+    prefix_pool_size=1,
+    num_workers=0,
 ):
     """
     Validate --prefix-len and --prefix-ratio options after CLI parsing completes.
@@ -468,6 +475,17 @@ def validate_prefix_options(
     if prefix_len is not None and prefix_ratio is not None:
         raise click.UsageError(
             "--prefix-len and --prefix-ratio are mutually exclusive. Use only one."
+        )
+
+    if prefix_pool_size > 1 and prefix_len is None:
+        raise click.UsageError(
+            "--prefix-pool-size greater than 1 requires --prefix-len."
+        )
+
+    if prefix_pool_size > 1 and num_workers > 0:
+        raise click.UsageError(
+            "--prefix-pool-size greater than 1 requires --num-workers 0 "
+            "to preserve a deterministic global prefix order."
         )
 
     # If neither is set, nothing to validate

--- a/genai_bench/sampling/text.py
+++ b/genai_bench/sampling/text.py
@@ -48,6 +48,8 @@ class TextSampler(Sampler):
         dataset_config: Optional[DatasetConfig] = None,
         prefix_len: Optional[int] = None,
         prefix_ratio: Optional[float] = None,
+        prefix_pool_size: int = 1,
+        prefix_seed: int = 42,
         **kwargs,
     ):
         super().__init__(
@@ -58,9 +60,15 @@ class TextSampler(Sampler):
         self.batch_size = 1  # Default batch size
         self.prefix_len = prefix_len
         self.prefix_ratio = prefix_ratio
+        if prefix_pool_size < 1:
+            raise ValueError("prefix_pool_size must be at least 1")
+        self.prefix_pool_size = prefix_pool_size
+        self.prefix_seed = prefix_seed
         # Globally shared prefix (generated once for --prefix-len,
         # per-request for --prefix-ratio)
         self._shared_prefix: Optional[str] = None
+        self._shared_prefixes: Optional[List[str]] = None
+        self._next_prefix_index = 0
 
     def sample(self, scenario: Optional[Scenario]) -> UserRequest:
         """
@@ -320,24 +328,14 @@ class TextSampler(Sampler):
         if not num_input_tokens:
             return random.choice(self.data)
 
-        # Fixed seed ensures multi-worker consistency; prefix_len in seed
-        # avoids cross-scenario cache overlap when prefix lengths differ.
         if effective_prefix_len is not None:
-            prefix_rng = random.Random(hash((42, effective_prefix_len)))
             if self.prefix_len is not None:
-                # --prefix-len mode: generate once and cache
-                if self._shared_prefix is None:
-                    self._shared_prefix = self._generate_text_from_dataset(
-                        effective_prefix_len, rng=prefix_rng
-                    )
-                    logger.info(
-                        f"Generated shared prefix ({effective_prefix_len} tokens) "
-                        f"from dataset for prefix caching. "
-                        f"This prefix will be reused across all requests."
-                    )
-                prefix = self._shared_prefix
+                prefix = self._get_shared_prefix(effective_prefix_len)
             else:
                 # --prefix-ratio mode: generate fresh prefix per-request
+                # Fixed seed ensures multi-worker consistency; prefix length in
+                # the seed avoids cross-scenario cache overlap.
+                prefix_rng = random.Random(hash((42, effective_prefix_len)))
                 prefix = self._generate_text_from_dataset(
                     effective_prefix_len, rng=prefix_rng
                 )
@@ -380,6 +378,57 @@ class TextSampler(Sampler):
         else:
             # No prefix caching - just return the full prompt
             return self._generate_text_from_dataset(num_input_tokens)
+
+    def _get_shared_prefix(self, prefix_len: int) -> str:
+        if self.prefix_pool_size == 1:
+            if self._shared_prefix is None:
+                # Preserve the existing single-prefix sequence when the default
+                # seed is used, while allowing callers to select another stable
+                # prefix explicitly.
+                prefix_rng = random.Random(hash((self.prefix_seed, prefix_len)))
+                self._shared_prefix = self._generate_text_from_dataset(
+                    prefix_len, rng=prefix_rng
+                )
+                logger.info(
+                    f"Generated shared prefix ({prefix_len} tokens) from dataset "
+                    "for prefix caching. This prefix will be reused across all "
+                    "requests."
+                )
+            return self._shared_prefix
+
+        if self._shared_prefixes is None:
+            self._shared_prefixes = [
+                self._generate_pool_prefix(prefix_len, index)
+                for index in range(self.prefix_pool_size)
+            ]
+            logger.info(
+                f"Generated {self.prefix_pool_size} shared prefixes "
+                f"({prefix_len} tokens each) for cyclic prefix caching."
+            )
+
+        prefix = self._shared_prefixes[
+            self._next_prefix_index % self.prefix_pool_size
+        ]
+        self._next_prefix_index += 1
+        return prefix
+
+    def _generate_pool_prefix(self, prefix_len: int, prefix_index: int) -> str:
+        marker = (
+            f"[GENAI_BENCH_PREFIX_{self.prefix_seed}_{prefix_len}_"
+            f"{prefix_index:04d}] "
+        )
+        marker_len = self.get_token_length(marker)
+        if marker_len >= prefix_len:
+            raise ValueError(
+                f"prefix_len ({prefix_len}) must exceed marker length "
+                f"({marker_len}) for multi-prefix sampling"
+            )
+
+        body = self._generate_text_from_dataset(
+            prefix_len - marker_len,
+            rng=random.Random(f"{self.prefix_seed}:{prefix_len}:{prefix_index}"),
+        )
+        return f"{marker}{body}"
 
     def _generate_text_from_dataset(
         self, num_tokens: int, rng: random.Random | None = None
@@ -430,6 +479,8 @@ class TextSampler(Sampler):
     def reset_prefix_cache(self):
         """Reset the prefix cache when switching to a new scenario."""
         self._shared_prefix = None
+        self._shared_prefixes = None
+        self._next_prefix_index = 0
 
     def _check_discrepancy(
         self, num_input_tokens: int, num_prefill_tokens: int, threshold: float = 0.1

--- a/tests/cli/test_cli_benchmark.py
+++ b/tests/cli/test_cli_benchmark.py
@@ -851,3 +851,41 @@ def test_prefix_len_option_in_help(cli_runner):
     assert result.exit_code == 0
     assert "--prefix-len" in result.output
     assert "prefix caching" in result.output
+    assert "--prefix-pool-size" in result.output
+    assert "--prefix-seed" in result.output
+
+
+@pytest.mark.usefixtures(
+    "mock_env_variables",
+    "mock_dashboard",
+    "mock_validate_tokenizer",
+    "mock_time_sleep",
+    "mock_makedirs",
+    "mock_file_system",
+    "mock_report_and_plot",
+    "mock_http_requests",
+    "mock_experiment_path",
+)
+def test_benchmark_command_with_prefix_pool(cli_runner, default_options):
+    with patch("genai_bench.cli.cli.Sampler.create") as mock_sampler_create:
+        result = cli_runner.invoke(
+            benchmark,
+            [
+                *default_options,
+                "--traffic-scenario",
+                "D(100,100)",
+                "--prefix-len",
+                "50",
+                "--prefix-pool-size",
+                "3",
+                "--prefix-seed",
+                "7",
+                "--num-workers",
+                "0",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed with output: {result.output}"
+        call_kwargs = mock_sampler_create.call_args.kwargs
+        assert call_kwargs["prefix_pool_size"] == 3
+        assert call_kwargs["prefix_seed"] == 7

--- a/tests/cli/test_validation.py
+++ b/tests/cli/test_validation.py
@@ -685,3 +685,38 @@ def test_validate_prefix_len_with_dataset_scenario():
         dataset_config=None,
         traffic_scenario=["D(100,50)", "D(200,100)"],
     )
+
+
+def test_validate_prefix_pool_options():
+    from genai_bench.cli.validation import validate_prefix_options
+
+    common = {
+        "prefix_ratio": None,
+        "task": "text-to-text",
+        "dataset_path": None,
+        "dataset_config": None,
+        "traffic_scenario": ["D(100,50)"],
+    }
+
+    with pytest.raises(click.UsageError, match="requires --prefix-len"):
+        validate_prefix_options(
+            prefix_len=None,
+            prefix_pool_size=2,
+            num_workers=0,
+            **common,
+        )
+
+    with pytest.raises(click.UsageError, match="requires --num-workers 0"):
+        validate_prefix_options(
+            prefix_len=50,
+            prefix_pool_size=2,
+            num_workers=1,
+            **common,
+        )
+
+    validate_prefix_options(
+        prefix_len=50,
+        prefix_pool_size=2,
+        num_workers=0,
+        **common,
+    )

--- a/tests/sampling/test_text.py
+++ b/tests/sampling/test_text.py
@@ -346,6 +346,40 @@ class TestTextSampler(unittest.TestCase):
             "Prompts should be different due to random hash separators",
         )
 
+    def test_prefix_pool_cycles_deterministically(self):
+        prefix_sampler = TextSampler(
+            tokenizer=self.tokenizer,
+            model=self.model,
+            output_modality=self.output_modality,
+            data=self.test_data,
+            prefix_len=20,
+            prefix_pool_size=3,
+            prefix_seed=7,
+        )
+        self.tokenizer.encode.side_effect = lambda text, **_: list(text.split())
+        self.tokenizer.decode.side_effect = lambda tokens, **_: " ".join(tokens)
+
+        prefixes = [prefix_sampler._get_shared_prefix(20) for _ in range(4)]
+
+        self.assertIn("GENAI_BENCH_PREFIX_7_20_0000", prefixes[0])
+        self.assertIn("GENAI_BENCH_PREFIX_7_20_0001", prefixes[1])
+        self.assertIn("GENAI_BENCH_PREFIX_7_20_0002", prefixes[2])
+        self.assertEqual(prefixes[0], prefixes[3])
+        self.assertEqual(len(set(prefixes[:3])), 3)
+        # Each prefix carries its unique marker plus a non-empty body. The exact
+        # re-encoded token count is only approximate (the dataset generator sums
+        # per-line token counts and joins lines without separators, so counting
+        # is not exact across the boundary), so assert the length stays within
+        # the requested budget rather than an exact match.
+        for prefix in prefixes:
+            self.assertTrue(prefix.startswith("[GENAI_BENCH_PREFIX_7_20_"))
+            token_len = len(self.tokenizer.encode(prefix))
+            self.assertGreater(token_len, 0)
+            self.assertLessEqual(token_len, 20)
+
+        prefix_sampler.reset_prefix_cache()
+        self.assertEqual(prefix_sampler._get_shared_prefix(20), prefixes[0])
+
     def test_sample_image_generation_request(self):
         """Test image generation request sampling."""
         image_sampler = TextSampler(


### PR DESCRIPTION
## Description
<!--Please provide a brief description of the changes in this PR.-->
Adds **deterministic prefix pools** to the text sampler. Two new sampling options — `--prefix-pool-size` and `--prefix-seed` — let a run rotate through a bounded set of *distinct* shared prefixes instead of the single shared prefix that `--prefix-len` provides today.

This makes it possible to benchmark a **bounded KV-cache working set** (many warm prefixes competing for cache) rather than one perpetually-hot prefix. For example, `--prefix-len 3072 --prefix-pool-size 20` exercises an aggregate shared-prefix working set of ~61k tokens across 20 distinct prefixes; concurrency controls how many requests are in flight but does not change the deterministic prefix order.

Each pool entry is stamped with a unique, seed-derived marker (`[GENAI_BENCH_PREFIX_<seed>_<len>_<idx>]`) so entries diverge from the very first token and the server treats them as separate prefix-cache entries. Prefixes are generated from a stable string seed, so the pool is reproducible across runs and across targets. Default behavior is unchanged: `--prefix-pool-size 1` with the default seed `42` reproduces the exact single-prefix sequence as before.

## Related Issue
<!--
Automatically closes linked issue when PR is merged.
Usage: Fixes #<issue number>, or Fixes (paste link of issue).
-->
N/A <!-- replace with `Fixes #<issue>` if there is a tracking issue -->

## Changes
<!--
List the changes made in this PR.
-->
- **`genai_bench/cli/option_groups.py`** — add `--prefix-pool-size` (`IntRange(min=1)`, default `1`) and `--prefix-seed` (`int`, default `42`).
- **`genai_bench/cli/validation.py`** — `validate_prefix_options` now rejects `--prefix-pool-size > 1` unless `--prefix-len` is set and `--num-workers 0`, preserving a single deterministic global rotation order.
- **`genai_bench/cli/cli.py`** — thread the new options through validation and into `Sampler.create`.
- **`genai_bench/sampling/text.py`** — add `_get_shared_prefix` (cyclic pool selection with wrap-around) and `_generate_pool_prefix` (unique marker + seeded body); `reset_prefix_cache` now also clears the pool and rotation index. The single-prefix path is generalized to honor `--prefix-seed` while staying byte-for-byte identical under the default seed.
- **`docs/user-guide/scenario-definition.md`** — document the feature, its requirements, and a runnable example.
- **Tests** — add coverage for cyclic determinism/reset, CLI validation, and end-to-end option plumbing.

## Correctness Tests
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->
Full suite: `make test` → **1000 passed, 6 skipped, total coverage 93%**. Targeted new tests:

```bash
uv run pytest tests/sampling/test_text.py \
              tests/cli/test_validation.py::test_validate_prefix_pool_options \
              tests/cli/test_cli_benchmark.py::test_benchmark_command_with_prefix_pool -vv
```

- `test_prefix_pool_cycles_deterministically` — the pool rotates through distinct marked prefixes, wraps around, and regenerates identically after `reset_prefix_cache()`.
- `test_validate_prefix_pool_options` — pool size > 1 requires `--prefix-len` and `--num-workers 0`.
- `test_benchmark_command_with_prefix_pool` — options reach `Sampler.create` with the right values.

Empirical token-count validation with a real tokenizer (gpt2) on realistic prose: pool prefixes stay within the requested budget, drifting ≤1–2 tokens at the marker↔body boundary (e.g. target `3072` → `3071–3072`), well below the `_check_discrepancy` warning threshold. Each pool entry is generated once and reused byte-for-byte, so prefix-cache hit behavior is fully deterministic across requests.

---
<details>
<summary> Checklist </summary>

- [x] I have rebased my branch on top of the latest main branch (`git pull origin main`) <!-- currently 2 commits behind origin/main; rebase before merge -->
- [x] I have run `make check` to ensure code is properly formatted and passes all lint checks
- [x] I have run `make test` or `make test_changed` to verify test coverage (~90% required)
- [ ] I have added tests that fail without my code changes (for bug fixes) <!-- N/A: feature, not a bug fix -->
- [x] I have added tests covering variants of new features (for new features)

</details>