### PR TITLE
[Draft](oci-openai): preserve stream timing and ignore_eos

### DIFF
--- a/genai_bench/user/oci_openai_user.py
+++ b/genai_bench/user/oci_openai_user.py
@@ -2,9 +2,14 @@
 
 from locust import task
 
+import json
+import os
 import time
+from collections.abc import Callable, Iterator
+from typing import Any
 
 import httpx
+import requests
 from oci_openai import (
     OciInstancePrincipalAuth,
     OciResourcePrincipalAuth,
@@ -15,8 +20,10 @@ from openai import OpenAI
 
 from genai_bench.logging import init_logger
 from genai_bench.protocol import (
+    UserChatResponse,
     UserImageGenerationRequest,
     UserImageGenerationResponse,
+    UserResponse,
     UserTextToSpeechRequest,
     UserTextToSpeechResponse,
 )
@@ -31,12 +38,17 @@ OCI_AUTH_CLASS_MAP = {
     "oci_obo_token": OciResourcePrincipalAuth,
 }
 
+DEFAULT_STREAM_CHUNK_SIZE = 1
+DEFAULT_MAX_PLAUSIBLE_OUTPUT_TPS = 2000.0
+COALESCED_STREAM_STATUS_CODE = 598
+
 
 class OCIOpenAIUser(OpenAIUser):
     """User class for OCI's OpenAI-compatible endpoints."""
 
     BACKEND_NAME = "oci-openai"
     supported_tasks = {
+        "text-to-text": "chat",
         "text-to-image": "images_generations",
         "text-to-speech": "speech",
     }
@@ -62,13 +74,218 @@ class OCIOpenAIUser(OpenAIUser):
         else:
             oci_auth = auth_cls()
 
+        self._oci_auth = oci_auth
         self.openai_client = OpenAI(
             api_key="OCI",
             base_url=self.host,
-            http_client=httpx.Client(auth=oci_auth),
+            http_client=httpx.Client(auth=oci_auth, trust_env=False),
         )
         self.api_backend = getattr(self, "api_backend", self.BACKEND_NAME)
         super(OpenAIUser, self).on_start()
+
+    @staticmethod
+    def _is_token_bearing_sse_line(line: bytes | str) -> bool:
+        text = (
+            line.decode("utf-8", errors="replace") if isinstance(line, bytes) else line
+        )
+        if not text.startswith("data:"):
+            return False
+
+        data_text = text[5:].strip()
+        if not data_text or data_text == "[DONE]":
+            return False
+
+        try:
+            event = json.loads(data_text)
+        except json.JSONDecodeError:
+            return False
+
+        for choice in event.get("choices") or []:
+            delta = choice.get("delta") or {}
+            if (
+                delta.get("content")
+                or delta.get("reasoning")
+                or delta.get("reasoning_content")
+            ):
+                return True
+        return False
+
+    @classmethod
+    def _use_low_latency_iter_lines(cls, response: requests.Response) -> None:
+        """Yield SSE lines as bytes arrive and count independently timed events."""
+        configured_chunk_size = int(
+            os.environ.get(
+                "OCI_OPENAI_STREAM_CHUNK_SIZE",
+                str(DEFAULT_STREAM_CHUNK_SIZE),
+            )
+        )
+        if configured_chunk_size <= 0:
+            raise ValueError("OCI_OPENAI_STREAM_CHUNK_SIZE must be a positive integer")
+
+        original_iter_lines = response.iter_lines
+        response._genai_bench_token_event_count = 0
+
+        def iter_lines(
+            chunk_size: int | None = None,
+            decode_unicode: bool = False,
+            delimiter: bytes | str | None = None,
+        ) -> Iterator[bytes | str]:
+            effective_chunk_size = (
+                configured_chunk_size if chunk_size is None else chunk_size
+            )
+            for line in original_iter_lines(
+                chunk_size=effective_chunk_size,
+                decode_unicode=decode_unicode,
+                delimiter=delimiter,
+            ):
+                if cls._is_token_bearing_sse_line(line):
+                    response._genai_bench_token_event_count += 1
+                yield line
+
+        response.iter_lines = iter_lines
+
+    @staticmethod
+    def _reject_unreliable_stream_timing(
+        metrics_response: UserResponse,
+        response: requests.Response,
+    ) -> UserResponse:
+        """Reject coalesced streams instead of reporting invalid decode timing."""
+        if not isinstance(metrics_response, UserChatResponse):
+            return metrics_response
+
+        first_token_time = metrics_response.time_at_first_token
+        end_time = metrics_response.end_time
+        tokens_received = metrics_response.tokens_received
+        if first_token_time is None or end_time is None or tokens_received is None:
+            return metrics_response
+        if tokens_received <= 1:
+            return metrics_response
+
+        max_output_tps = float(
+            os.environ.get(
+                "OCI_OPENAI_MAX_PLAUSIBLE_OUTPUT_TPS",
+                str(DEFAULT_MAX_PLAUSIBLE_OUTPUT_TPS),
+            )
+        )
+        if max_output_tps <= 0:
+            raise ValueError(
+                "OCI_OPENAI_MAX_PLAUSIBLE_OUTPUT_TPS must be a positive number"
+            )
+
+        token_event_count = int(getattr(response, "_genai_bench_token_event_count", 0))
+        output_duration_s = end_time - first_token_time
+        observed_output_tps = (
+            float("inf")
+            if output_duration_s <= 0
+            else (tokens_received - 1) / output_duration_s
+        )
+        if token_event_count > 1 and observed_output_tps <= max_output_tps:
+            return metrics_response
+
+        reasons = []
+        if token_event_count <= 1:
+            reasons.append(f"only {token_event_count} token-bearing SSE event(s)")
+        if observed_output_tps > max_output_tps:
+            reasons.append(
+                f"{observed_output_tps:.1f} tokens/s exceeds {max_output_tps:.1f}"
+            )
+
+        return UserResponse(
+            status_code=COALESCED_STREAM_STATUS_CODE,
+            error_message=(
+                "Unreliable coalesced-stream timing: "
+                + "; ".join(reasons)
+                + f"; {tokens_received} output tokens arrived over "
+                f"{output_duration_s:.6f}s after the first observed content. "
+                "The request is rejected instead of recording invalid "
+                "TTFT/TPOT/output-speed metrics."
+            ),
+            start_time=metrics_response.start_time,
+            time_at_first_token=first_token_time,
+            end_time=end_time,
+            num_prefill_tokens=metrics_response.num_prefill_tokens,
+        )
+
+    def send_request(
+        self,
+        stream: bool,
+        endpoint: str,
+        payload: dict[str, Any],
+        parse_strategy: Callable[..., UserResponse],
+        num_prefill_tokens: int | None = None,
+    ) -> UserResponse:
+        """Send an OCI-signed request without buffering streaming token events."""
+        response = None
+        try:
+            start_time = time.monotonic()
+            request_payload = dict(payload)
+            compartment_id = request_payload.pop(
+                "compartmentId", None
+            ) or os.environ.get("OCI_GENAI_COMPARTMENT_ID")
+            headers = {
+                "Content-Type": "application/json",
+                "Accept-Encoding": "identity",
+            }
+            if compartment_id:
+                headers["CompartmentId"] = compartment_id
+                headers["opc-compartment-id"] = compartment_id
+
+            request = requests.Request(
+                method="POST",
+                url=f"{self.host}{endpoint}",
+                json=request_payload,
+                headers=headers,
+            )
+            prepared = request.prepare()
+            self._oci_auth.signer.do_request_sign(prepared)
+
+            with requests.Session() as session:
+                session.trust_env = False
+                response = session.send(
+                    prepared,
+                    stream=stream,
+                    timeout=(60, 600),
+                )
+                request_end_time = time.monotonic()
+
+                if response.status_code == 200:
+                    if stream:
+                        self._use_low_latency_iter_lines(response)
+                    metrics_response = parse_strategy(
+                        response,
+                        start_time,
+                        num_prefill_tokens,
+                        request_end_time,
+                    )
+                    if stream:
+                        metrics_response = self._reject_unreliable_stream_timing(
+                            metrics_response,
+                            response,
+                        )
+                else:
+                    metrics_response = UserResponse(
+                        status_code=response.status_code,
+                        error_message=response.text,
+                    )
+        except requests.exceptions.ConnectionError as e:
+            metrics_response = UserResponse(
+                status_code=503, error_message=f"Connection error: {e}"
+            )
+        except requests.exceptions.Timeout as e:
+            metrics_response = UserResponse(
+                status_code=408, error_message=f"Request timed out: {e}"
+            )
+        except requests.exceptions.RequestException as e:
+            metrics_response = UserResponse(
+                status_code=500,
+                error_message=str(e),
+            )
+        finally:
+            if response is not None:
+                response.close()
+
+        self.collect_metrics(metrics_response, endpoint)
+        return metrics_response
 
     @task
     def images_generations(self):

--- a/genai_bench/user/oci_openai_user.py
+++ b/genai_bench/user/oci_openai_user.py
@@ -6,7 +6,7 @@ import json
 import os
 import time
 from collections.abc import Callable, Iterator
-from typing import Any
+from typing import Any, cast
 
 import httpx
 import requests
@@ -122,8 +122,12 @@ class OCIOpenAIUser(OpenAIUser):
         if configured_chunk_size <= 0:
             raise ValueError("OCI_OPENAI_STREAM_CHUNK_SIZE must be a positive integer")
 
-        original_iter_lines = response.iter_lines
-        response._genai_bench_token_event_count = 0
+        response_state = cast(Any, response)
+        original_iter_lines = cast(
+            Callable[..., Iterator[bytes | str]],
+            response.iter_lines,
+        )
+        response_state._genai_bench_token_event_count = 0
 
         def iter_lines(
             chunk_size: int | None = None,
@@ -139,10 +143,10 @@ class OCIOpenAIUser(OpenAIUser):
                 delimiter=delimiter,
             ):
                 if cls._is_token_bearing_sse_line(line):
-                    response._genai_bench_token_event_count += 1
+                    response_state._genai_bench_token_event_count += 1
                 yield line
 
-        response.iter_lines = iter_lines
+        response_state.iter_lines = iter_lines
 
     @staticmethod
     def _reject_unreliable_stream_timing(

--- a/genai_bench/user/openai_user.py
+++ b/genai_bench/user/openai_user.py
@@ -107,11 +107,13 @@ class OpenAIUser(BaseUser):
             **filtered_params,
         }
 
-        # Conditionally add ignore_eos for vLLM and SGLang backends
+        # Conditionally add ignore_eos for vLLM and SGLang backends.
         if self.api_backend in ["vllm", "sglang"]:
             payload.setdefault("ignore_eos", bool(user_request.max_tokens))
-        else:
-            # Remove ignore_eos for OpenAI backend, as it is not supported
+        elif self.api_backend != "oci-openai":
+            # OCI's OpenAI-compatible endpoint can pass explicit vLLM extension
+            # parameters through to the serving runtime. Other OpenAI-compatible
+            # providers may reject this non-standard field.
             payload.pop("ignore_eos", None)
 
         self.send_request(

--- a/tests/user/test_oci_openai_user.py
+++ b/tests/user/test_oci_openai_user.py
@@ -1,13 +1,19 @@
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from genai_bench.protocol import (
+    UserChatResponse,
     UserChatRequest,
     UserImageGenerationRequest,
     UserImageGenerationResponse,
 )
-from genai_bench.user.oci_openai_user import OCI_AUTH_CLASS_MAP, OCIOpenAIUser
+from genai_bench.user.oci_openai_user import (
+    COALESCED_STREAM_STATUS_CODE,
+    OCI_AUTH_CLASS_MAP,
+    OCIOpenAIUser,
+)
 
 
 @pytest.fixture
@@ -45,6 +51,163 @@ def test_on_start_session_auth(mock_openai, mock_oci_openai_user):
     mock_auth_cls = OCI_AUTH_CLASS_MAP["oci_security_token"]
     mock_auth_cls.assert_called_once_with(profile_name="DEFAULT")
     mock_openai.assert_called_once()
+
+
+def test_text_to_text_task_is_supported():
+    assert OCIOpenAIUser.supported_tasks["text-to-text"] == "chat"
+
+
+class FakeStreamingResponse:
+    def __init__(self, lines):
+        self.lines = lines
+        self.chunk_sizes = []
+        self._genai_bench_token_event_count = 0
+
+    def iter_lines(self, chunk_size=None, decode_unicode=False, delimiter=None):
+        self.chunk_sizes.append(chunk_size)
+        return iter(self.lines)
+
+
+def _chat_response(*, first_token_time=1.0, end_time=2.0, tokens_received=4):
+    return UserChatResponse(
+        status_code=200,
+        generated_text="test",
+        tokens_received=tokens_received,
+        time_at_first_token=first_token_time,
+        num_prefill_tokens=5,
+        start_time=0.0,
+        end_time=end_time,
+    )
+
+
+def test_low_latency_iter_lines_counts_token_events(monkeypatch):
+    monkeypatch.setenv("OCI_OPENAI_STREAM_CHUNK_SIZE", "1")
+    response = FakeStreamingResponse(
+        [
+            b'data: {"choices":[{"delta":{"content":"one"}}]}',
+            b'data: {"choices":[{"delta":{"reasoning_content":"two"}}]}',
+            b'data: {"choices":[{"delta":{},"finish_reason":"length"}]}',
+            b"data: [DONE]",
+        ]
+    )
+
+    OCIOpenAIUser._use_low_latency_iter_lines(response)
+
+    assert list(response.iter_lines(chunk_size=None)) == response.lines
+    assert response.chunk_sizes == [1]
+    assert response._genai_bench_token_event_count == 2
+
+
+def test_coalesced_stream_timing_is_rejected(monkeypatch):
+    monkeypatch.setenv("OCI_OPENAI_MAX_PLAUSIBLE_OUTPUT_TPS", "2000")
+    response = FakeStreamingResponse([])
+    response._genai_bench_token_event_count = 1
+
+    result = OCIOpenAIUser._reject_unreliable_stream_timing(
+        _chat_response(first_token_time=1.0, end_time=2.0),
+        response,
+    )
+
+    assert result.status_code == COALESCED_STREAM_STATUS_CODE
+    assert "only 1 token-bearing SSE event" in result.error_message
+
+
+def test_multi_event_plausible_stream_timing_is_preserved(monkeypatch):
+    monkeypatch.setenv("OCI_OPENAI_MAX_PLAUSIBLE_OUTPUT_TPS", "2000")
+    response = FakeStreamingResponse([])
+    response._genai_bench_token_event_count = 2
+    metrics_response = _chat_response(first_token_time=1.0, end_time=2.0)
+
+    result = OCIOpenAIUser._reject_unreliable_stream_timing(
+        metrics_response,
+        response,
+    )
+
+    assert result is metrics_response
+
+
+def test_multi_event_impossible_stream_timing_is_rejected(monkeypatch):
+    monkeypatch.setenv("OCI_OPENAI_MAX_PLAUSIBLE_OUTPUT_TPS", "2000")
+    response = FakeStreamingResponse([])
+    response._genai_bench_token_event_count = 2
+
+    result = OCIOpenAIUser._reject_unreliable_stream_timing(
+        _chat_response(
+            first_token_time=1.0,
+            end_time=1.001,
+            tokens_received=512,
+        ),
+        response,
+    )
+
+    assert result.status_code == COALESCED_STREAM_STATUS_CODE
+    assert "tokens/s exceeds 2000.0" in result.error_message
+
+
+@patch("genai_bench.user.oci_openai_user.requests.Session")
+def test_send_request_signs_low_latency_stream(mock_session, mock_oci_openai_user):
+    response = FakeStreamingResponse(
+        [
+            b'data: {"choices":[{"delta":{"content":"one"}}]}',
+            b'data: {"choices":[{"delta":{"content":"two"}}]}',
+            b"data: [DONE]",
+        ]
+    )
+    response.status_code = 200
+    response.close = MagicMock()
+
+    session = MagicMock()
+    session.__enter__.return_value = session
+    session.send.return_value = response
+    mock_session.return_value = session
+
+    mock_oci_openai_user._oci_auth = MagicMock()
+    mock_oci_openai_user.collect_metrics = MagicMock()
+
+    def parse_strategy(stream_response, start_time, num_prefill_tokens, _):
+        assert list(stream_response.iter_lines(chunk_size=None)) == response.lines
+        return UserChatResponse(
+            status_code=200,
+            generated_text="onetwo",
+            tokens_received=2,
+            time_at_first_token=start_time + 0.5,
+            num_prefill_tokens=num_prefill_tokens,
+            start_time=start_time,
+            end_time=start_time + 1.0,
+        )
+
+    result = mock_oci_openai_user.send_request(
+        stream=True,
+        endpoint="/v1/chat/completions",
+        payload={
+            "model": "test-model",
+            "stream": True,
+            "ignore_eos": True,
+            "compartmentId": "ocid1.compartment.oc1..test",
+        },
+        parse_strategy=parse_strategy,
+        num_prefill_tokens=5,
+    )
+
+    prepared_request = session.send.call_args.args[0]
+    request_body = json.loads(prepared_request.body)
+    assert request_body["ignore_eos"] is True
+    assert "compartmentId" not in request_body
+    assert prepared_request.headers["Accept-Encoding"] == "identity"
+    assert prepared_request.headers["CompartmentId"] == "ocid1.compartment.oc1..test"
+    assert prepared_request.headers["opc-compartment-id"] == (
+        "ocid1.compartment.oc1..test"
+    )
+    assert session.trust_env is False
+    assert response.chunk_sizes == [1]
+    assert response._genai_bench_token_event_count == 2
+    mock_oci_openai_user._oci_auth.signer.do_request_sign.assert_called_once_with(
+        prepared_request
+    )
+    mock_oci_openai_user.collect_metrics.assert_called_once_with(
+        result,
+        "/v1/chat/completions",
+    )
 
 
 @patch("genai_bench.user.oci_openai_user.OpenAI")

--- a/tests/user/test_openai_user.py
+++ b/tests/user/test_openai_user.py
@@ -1364,6 +1364,37 @@ def test_ignore_eos_sglang_backend_explicit_false(mock_post, mock_openai_user):
 
 
 @patch("genai_bench.user.openai_user.requests.post")
+def test_ignore_eos_oci_openai_backend_explicit_true(mock_post, mock_openai_user):
+    """Test that explicit ignore_eos=True is preserved for OCI OpenAI."""
+    mock_openai_user.on_start()
+    mock_openai_user.api_backend = "oci-openai"
+    mock_openai_user.sample = lambda: UserChatRequest(
+        model="gpt-3",
+        prompt="Hello",
+        num_prefill_tokens=5,
+        additional_request_params={"ignore_eos": True},
+        max_tokens=10,
+    )
+
+    response_mock = MagicMock()
+    response_mock.status_code = 200
+    response_mock.iter_lines = MagicMock(
+        return_value=[
+            b'data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}',
+            b'data: {"choices":[{"delta":{},"finish_reason":"length"}],'
+            b'"usage":{"prompt_tokens":5,"completion_tokens":10,"total_tokens":15}}',
+            b"data: [DONE]",
+        ]
+    )
+    mock_post.return_value = response_mock
+
+    mock_openai_user.chat()
+
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload["ignore_eos"] is True
+
+
+@patch("genai_bench.user.openai_user.requests.post")
 def test_ignore_eos_openai_backend_removed(mock_post, mock_openai_user):
     """Test that ignore_eos is removed for OpenAI backend."""
     mock_openai_user.on_start()


### PR DESCRIPTION
## Summary

This PR upstreams the reusable OCI OpenAI benchmarking behavior that previously
required a local wrapper:

- enables the inherited `text-to-text` task for `--api-backend oci-openai`;
- preserves an explicitly supplied `ignore_eos` request parameter;
- sends OCI-signed chat requests through an uncompressed, low-latency SSE path;
- counts independently delivered token-bearing SSE events; and
- rejects coalesced or physically implausible stream timing with client-side
  status `598` instead of recording invalid TTFT, TPOT, or output inference speed.

Model-specific prompt changes are intentionally not included.

## Why

Buffered or coalesced streaming can make a completion containing hundreds of
tokens appear to arrive immediately after its first token. That produces
impossible per-request inference speeds even though request latency and aggregate
server throughput may still look reasonable. OCI vLLM deployments may also
support `ignore_eos`, but the generic OpenAI backend previously removed that
non-standard field.

## How to use

### Install the branch directly

```bash
python -m pip install \
  "git+https://github.com/OpheliaLjh/genai-bench.git@codex/oci-openai-stream-timing-ignore-eos"
```

Or clone it:

```bash
git clone \
  --branch codex/oci-openai-stream-timing-ignore-eos \
  --single-branch \
  https://github.com/OpheliaLjh/genai-bench.git
cd genai-bench
python -m pip install -e .
```

### Run an OCI OpenAI benchmark

```bash
export OCI_PROFILE=DEFAULT
export REGION=eu-frankfurt-1
export OCI_GENAI_COMPARTMENT_ID="<compartment-or-tenancy-ocid>"

# Defaults shown explicitly for reproducibility.
export OCI_OPENAI_STREAM_CHUNK_SIZE=1
export OCI_OPENAI_MAX_PLAUSIBLE_OUTPUT_TPS=2000
export ENABLE_UI=false

genai-bench benchmark \
  --api-backend oci-openai \
  --api-base "https://inference.generativeai.${REGION}.oci.oraclecloud.com/20231130/actions" \
  --api-model-name "<endpoint-ocid>" \
  --model-tokenizer "<tokenizer-name-or-local-path>" \
  --task text-to-text \
  --auth security_token \
  --profile "$OCI_PROFILE" \
  --region "$REGION" \
  --traffic-scenario "D(1024,512)" \
  --num-concurrency 1 \
  --max-time-per-run 10 \
  --max-requests-per-run 500 \
  --additional-request-params '{"ignore_eos":true}'
```

The same flags can be used with the full traffic/concurrency matrix.

## Important behavior

- `ignore_eos` is preserved only when explicitly supplied. This PR does not add
  it automatically to every OCI model.
- `ignore_eos=true` asks a compatible serving runtime to continue until the
  requested maximum, but reports should still verify the resulting
  `num_output_tokens` distribution.
- Status `598` is generated by GenAI Bench, not returned by OCI. It means the
  observed SSE stream did not contain enough independently timed token events,
  or the derived per-request output speed exceeded
  `OCI_OPENAI_MAX_PLAUSIBLE_OUTPUT_TPS`.
- Increase the plausible-speed threshold only when the serving configuration has
  evidence that a higher single-request decode speed is physically valid.
- The OCI compartment can be supplied through `OCI_GENAI_COMPARTMENT_ID` or
  `compartmentId` in the additional request parameters. It is sent as an OCI
  request header rather than in the JSON body.

## Validation

- `89 passed`:
  `tests/user/test_oci_openai_user.py tests/user/test_openai_user.py`
- Ruff check: passed
- Ruff format check: passed
- mypy for both modified user modules: passed
- `git diff --check`: passed

The full local suite currently stops during collection because the shared
virtual environment has an older OCI SDK that does not provide
`CohereChatRequestV2`. That dependency mismatch is unrelated to the files
changed by this PR.
